### PR TITLE
Trigger internal deploy

### DIFF
--- a/.github/actions/notify-failure/action.yml
+++ b/.github/actions/notify-failure/action.yml
@@ -1,9 +1,10 @@
 name: notify-failure
-decription: Send a notification to Econ MS Teams channel
+description: Send a notification to Econ MS Teams channel
 
 inputs:
   webhook:
     required: true
+    description: The webhook URL to be called
 
 runs:
   using: composite

--- a/.github/actions/trigger-deploy/action.yml
+++ b/.github/actions/trigger-deploy/action.yml
@@ -1,0 +1,29 @@
+name: trigger-deploy
+description: Triggers a deploy in a remote location using cURL and payload
+
+inputs:
+  url:
+    required: true
+    description: The URL to trigger
+  token:
+    required: true
+    description: The auth token used for the trigger
+  ref:
+    default: main
+    description: The reference to trigger (commonly a branch name)
+  target:
+    default: staging
+    description: The deployment to trigger (staging or production)
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        curl -X POST \
+          --fail \
+          -F token=${{ inputs.token }} \
+          -F "ref=main" \
+          -F "variables[REF_NAME]=$GITHUB_REF_NAME" \
+          -F "variables[POOL_DEPLOY_TARGET]=${{ inputs.target }}" \
+          ${{ inputs.url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 on:
-  pull_request:
   push:
-    branches: [main]
-    tags: ["v*"]
 
 jobs:
   build:
@@ -102,6 +99,17 @@ jobs:
         uses: ./.github/actions/notify-failure
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
+
+  deploy:
+    name: Trigger staging deploy
+    runs-on: ubuntu-latest
+    needs: [build, assets]
+    if: github.ref_type != 'tag'
+    steps:
+      - uses: ./.github/actions/notify-failure
+        with:
+          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
+          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
 
   release:
     name: Release a new version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Trigger staging deploy
         if: github.ref_type != 'tag'
-        uses: ./.github/actions/notify-failure
+        uses: ./.github/actions/trigger-deploy
         with:
           url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
           token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
-      - uses: ./.github/actions/notify-failure
+      - uses: ./.github/actions/trigger-deploy
         with:
           url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
           token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
+  pull_request:
   push:
+    branches: [main]
+    tags: ["v*"]
 
 jobs:
   build:
@@ -30,9 +33,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Build and test with Docker
+        uses: addnab/docker-run-action@v3
+        env:
+          DATABASE_URL: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@database-root:3306/${{ env.MYSQL_DATABASE }}
+          DATABASE_URL_TENANT_TEST: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@database-tenant:3306/${{ env.MYSQL_DATABASE }}
+          SIHL_ENV: test
+          SMTP_SENDER: test@econ.uzh.ch
+          TEST_EMAIL: test@econ.uzh.ch
+        with:
+          image: ocaml/opam:debian-10-ocaml-4.12
+          options: -v ${{ github.workspace }}:/app -w /app -e DATABASE_URL -e DATABASE_URL_TENANT_TEST -e TEST_EMAIL -e SMTP_SENDER -e SIHL_ENV
+          run: |
+            # Reclaim required directory permissions
+            sudo chown -R opam .
+
+            # Build and test executable
+            /app/scripts/build.sh || exit 1
+
+            # Restore directory permissions to avoid conflicts
+            sudo chown -R 1001:123 .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: run.exe
+          path: _build/default/pool/run/run.exe
 
       - name: Trigger staging deploy
-        if: github.ref_type != 'tag'
         uses: ./.github/actions/trigger-deploy
         with:
           url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
 
+      - name: Trigger staging deploy
+        if: github.ref_type != 'tag'
+        uses: ./.github/actions/notify-failure
+        with:
+          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
+          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
+
   assets:
     name: Build assets
     runs-on: ubuntu-latest
@@ -100,17 +107,6 @@ jobs:
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
 
-  deploy:
-    name: Trigger staging deploy
-    runs-on: ubuntu-latest
-    needs: [build, assets]
-    if: github.ref_type != 'tag'
-    steps:
-      - uses: ./.github/actions/notify-failure
-        with:
-          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
-          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
-
   release:
     name: Release a new version
     runs-on: ubuntu-latest
@@ -142,3 +138,13 @@ jobs:
         uses: ./.github/actions/notify-failure
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
+
+  deploy:
+    name: Trigger production deploy
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: ./.github/actions/notify-failure
+        with:
+          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
+          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             sudo chown -R opam .
 
             # Build and test executable
-            /app/scripts/build.sh
+            /app/scripts/build.sh || exit 1
 
             # Restore directory permissions to avoid conflicts
             sudo chown -R 1001:123 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,31 +30,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build and test with Docker
-        uses: addnab/docker-run-action@v3
-        env:
-          DATABASE_URL: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@database-root:3306/${{ env.MYSQL_DATABASE }}
-          DATABASE_URL_TENANT_TEST: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@database-tenant:3306/${{ env.MYSQL_DATABASE }}
-          SIHL_ENV: test
-          SMTP_SENDER: test@econ.uzh.ch
-          TEST_EMAIL: test@econ.uzh.ch
+
+      - name: Trigger staging deploy
+        if: github.ref_type != 'tag'
+        uses: ./.github/actions/trigger-deploy
         with:
-          image: ocaml/opam:debian-10-ocaml-4.12
-          options: -v ${{ github.workspace }}:/app -w /app -e DATABASE_URL -e DATABASE_URL_TENANT_TEST -e TEST_EMAIL -e SMTP_SENDER -e SIHL_ENV
-          run: |
-            # Reclaim required directory permissions
-            sudo chown -R opam .
-
-            # Build and test executable
-            /app/scripts/build.sh || exit 1
-
-            # Restore directory permissions to avoid conflicts
-            sudo chown -R 1001:123 .
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: run.exe
-          path: _build/default/pool/run/run.exe
+          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
+          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
 
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -67,13 +49,6 @@ jobs:
         uses: ./.github/actions/notify-failure
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
-
-      - name: Trigger staging deploy
-        if: github.ref_type != 'tag'
-        uses: ./.github/actions/trigger-deploy
-        with:
-          url: ${{ secrets.ECON_DEPLOY_TRIGGER_URL }}
-          token: ${{ secrets.ECON_DEPLOY_TRIGGER_TOKEN }}
 
   assets:
     name: Build assets


### PR DESCRIPTION
Use a GitHub action and secrets to deploy to our internal servers in staging and on release to production. This also fixes an error where the workflow does not stop if the build script fails.