### PR TITLE
pause sending invitations when no spots in sessions are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [unreleased](https://github.com/uzh/pool/tree/HEAD)
 
+### Added
+
+- pause sending invitations when no spots in sessions are available and add note on create mailing page
+
 ### Removed
 
 - Recruitment channel from contact module (add as custom field)

--- a/pool/app/pool_common/entity_i18n.ml
+++ b/pool/app/pool_common/entity_i18n.ml
@@ -23,6 +23,7 @@ type t =
   | LocationNoSessions
   | LoginTitle
   | MailingDetailTitle of Ptime.t
+  | MailingExperimentSessionFullyBooked
   | MailingNewTitle
   | NoEntries of Entity_message.Field.t
   | NotifyVia

--- a/pool/app/pool_common/locales/i18n_de.ml
+++ b/pool/app/pool_common/locales/i18n_de.ml
@@ -43,8 +43,8 @@ let to_string = function
   | MailingDetailTitle start ->
     Format.asprintf "Versand vom %s" (Utils_time.formatted_date_time start)
   | MailingExperimentSessionFullyBooked ->
-    "Keine freien Plätze in den Sessions. Es werden keine Einladungen \
-     versendet (unabhängig ob z.Z. Mailings aktiv sind).\n\n\
+    "Alle Sessions sind ausgebucht. Es werden keine Einladungen versendet \
+     (unabhängig ob z.Z. Mailings aktiv sind).\n\n\
      Füge zusätzliche Sessions zum Experiment hinzu."
   | MailingNewTitle -> "Neuen Versand erstellen"
   | RateTotalSent number ->

--- a/pool/app/pool_common/locales/i18n_de.ml
+++ b/pool/app/pool_common/locales/i18n_de.ml
@@ -42,6 +42,10 @@ let to_string = function
   | LoginTitle -> "Login"
   | MailingDetailTitle start ->
     Format.asprintf "Versand vom %s" (Utils_time.formatted_date_time start)
+  | MailingExperimentSessionFullyBooked ->
+    "Keine freien Plätze in den Sessions. Es werden keine Einladungen \
+     versendet (unabhängig ob z.Z. Mailings aktiv sind).\n\n\
+     Füge zusätzliche Sessions zum Experiment hinzu."
   | MailingNewTitle -> "Neuen Versand erstellen"
   | RateTotalSent number ->
     Format.asprintf "Total generierter Einladungen: %d" number

--- a/pool/app/pool_common/locales/i18n_en.ml
+++ b/pool/app/pool_common/locales/i18n_en.ml
@@ -40,8 +40,8 @@ let to_string = function
   | MailingDetailTitle start ->
     Format.asprintf "Mailing at %s" (Utils_time.formatted_date_time start)
   | MailingExperimentSessionFullyBooked ->
-    "No available spots for session registration. No invitations will be sent \
-     (independent if mailings are active at the moment).\n\n\
+    "All sessions are fully booked. No invitations will be sent (independent \
+     if mailings are active at the moment).\n\n\
      Add additional sessions to the experiment."
   | MailingNewTitle -> "Create new mailing"
   | RateTotalSent number ->

--- a/pool/app/pool_common/locales/i18n_en.ml
+++ b/pool/app/pool_common/locales/i18n_en.ml
@@ -39,6 +39,10 @@ let to_string = function
   | LoginTitle -> "Login"
   | MailingDetailTitle start ->
     Format.asprintf "Mailing at %s" (Utils_time.formatted_date_time start)
+  | MailingExperimentSessionFullyBooked ->
+    "No available spots for session registration. No invitations will be sent \
+     (independent if mailings are active at the moment).\n\n\
+     Add additional sessions to the experiment."
   | MailingNewTitle -> "Create new mailing"
   | RateTotalSent number ->
     Format.asprintf "Totally generated invitations: %d" number

--- a/pool/app/session/session.ml
+++ b/pool/app/session/session.ml
@@ -48,3 +48,13 @@ let build_cancellation_messages
     CCList.map create_message contacts)
   |> Lwt_result.return
 ;;
+
+let has_bookable_spots_for_experiments tenant experiment =
+  let open Utils.Lwt_result.Infix in
+  find_all_for_experiment tenant experiment
+  >|+ CCList.filter (fun session ->
+        CCOption.is_none session.Entity.follow_up_to
+        && not (Entity.is_fully_booked session))
+  >|+ CCList.is_empty
+  >|+ not
+;;

--- a/pool/app/session/session.mli
+++ b/pool/app/session/session.mli
@@ -207,6 +207,11 @@ val build_cancellation_messages
 val to_email_text : Pool_common.Language.t -> t -> string
 val public_to_email_text : Pool_common.Language.t -> Public.t -> string
 
+val has_bookable_spots_for_experiments
+  :  Pool_database.Label.t
+  -> Experiment.Id.t
+  -> (bool, Pool_common.Message.error) result Lwt.t
+
 module Guard : sig
   module Target : sig
     val to_authorizable

--- a/pool/matcher/matcher.ml
+++ b/pool/matcher/matcher.ml
@@ -185,7 +185,7 @@ let match_invitations ?interval pools =
               let find_experiment { Mailing.id; _ } =
                 Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
               in
-              let is_fully_booked { Experiment.id; _ } =
+              let is_not_fully_booked { Experiment.id; _ } =
                 Session.has_bookable_spots_for_experiments pool id
               in
               let validate = function
@@ -194,7 +194,7 @@ let match_invitations ?interval pools =
               in
               mailing
               |> find_experiment
-              >>= is_fully_booked
+              >>= is_not_fully_booked
               >== validate
               ||> CCResult.to_opt)
         ||> fun m -> pool, m)

--- a/pool/matcher/matcher.ml
+++ b/pool/matcher/matcher.ml
@@ -185,16 +185,16 @@ let match_invitations ?interval pools =
               let find_experiment { Mailing.id; _ } =
                 Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
               in
-              let is_not_fully_booked { Experiment.id; _ } =
+              let has_spots { Experiment.id; _ } =
                 Session.has_bookable_spots_for_experiments pool id
               in
               let validate = function
-                | false -> Ok mailing
-                | true -> Error Pool_common.Message.SessionFullyBooked
+                | true -> Ok mailing
+                | false -> Error Pool_common.Message.SessionFullyBooked
               in
               mailing
               |> find_experiment
-              >>= is_not_fully_booked
+              >>= has_spots
               >== validate
               ||> CCResult.to_opt)
         ||> fun m -> pool, m)

--- a/pool/web/handler/admin_experiments_mailing.ml
+++ b/pool/web/handler/admin_experiments_mailing.ml
@@ -33,7 +33,13 @@ let new_form req =
   let result ({ Pool_context.database_label; _ } as context) =
     Utils.Lwt_result.map_error (fun err -> err, experiment_path id)
     @@ let* experiment = Experiment.find database_label id in
+       let* is_bookable =
+         Session.has_bookable_spots_for_experiments
+           database_label
+           experiment.Experiment.id
+       in
        Page.Admin.Mailing.form
+         ~fully_booked:(not is_bookable)
          context
          experiment
          (CCFun.flip Sihl.Web.Flash.find req)


### PR DESCRIPTION
- pause sending invitations when no bookable spots are available
- add note to "create mailings" page
- cleanup mailings view file