### PR TITLE
assign also follow up sessions when registering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - don't logout contacts when answering required fields
 - experiments with active uninvited registration handle the experiment filter
 - effects for waiting list session registration (admin)
+- signup for follow up sessions is handled within the main session signup
 
 ## [0.0.3](https://github.com/uzh/pool/tree/0.0.3) - 2022-12-23
 

--- a/pool/app/assignment/assignment.mli
+++ b/pool/app/assignment/assignment.mli
@@ -56,7 +56,7 @@ val find_by_experiment_and_contact_opt
   :  Pool_database.Label.t
   -> Experiment.Id.t
   -> Contact.t
-  -> Public.t option Lwt.t
+  -> Public.t list Lwt.t
 
 val find_by_session
   :  Pool_database.Label.t

--- a/pool/app/assignment/repo/repo.ml
+++ b/pool/app/assignment/repo/repo.ml
@@ -131,11 +131,11 @@ module Sql = struct
         pool_assignments.contact_id = (SELECT id FROM pool_contacts WHERE pool_contacts.user_uuid = UNHEX(REPLACE(?, '-', '')))
     |sql}
     |> Format.asprintf "%s\n%s" select_public_sql
-    |> Caqti_type.(tup2 string string) ->! RepoEntity.Public.t
+    |> Caqti_type.(tup2 string string) ->* RepoEntity.Public.t
   ;;
 
   let find_by_experiment_and_contact_opt pool experiment_id contact =
-    Utils.Database.find_opt
+    Utils.Database.collect
       (Pool_database.Label.value pool)
       find_by_experiment_and_contact_opt_request
       ( Experiment.Id.value experiment_id

--- a/pool/app/pool_common/entity_i18n.ml
+++ b/pool/app/pool_common/entity_i18n.ml
@@ -122,6 +122,7 @@ type hint =
   | SessionClose
   | SessionReminderLanguageHint
   | SessionRegistrationHint
+  | SessionRegistrationFollowUpHint
   | SignUpForWaitingList
   | TemplateTextElementsHint
   | TimeSpanPickerHint

--- a/pool/app/pool_common/entity_message.ml
+++ b/pool/app/pool_common/entity_message.ml
@@ -278,6 +278,7 @@ type error =
   | SessionFullyBooked
   | SessionHasAssignments
   | SessionInvalid
+  | SessionRegistrationViaParent
   | SessionTenantNotFound
   | ReadOnlyModel
   | ReminderSubjectAndTextRequired

--- a/pool/app/pool_common/locales/i18n_de.ml
+++ b/pool/app/pool_common/locales/i18n_de.ml
@@ -15,7 +15,7 @@ let to_string = function
       "Es sind keine %s vorhanden."
       (Locales_de.field_to_string field)
   | ExperimentContactEnrolledNote ->
-    "Sie sind an der folgenden Session angemeldet:"
+    "Sie sind an der/den folgenden Session(s) angemeldet:"
   | Files -> "Dateien"
   | FilterNrOfContacts ->
     "Anzahl der Kontakte, die den Kriterien dieses Filters entsprechen:"
@@ -60,6 +60,7 @@ let to_string = function
   | SentInvitations -> "Versendete Einladungen"
   | SessionDetailTitle start ->
     Format.asprintf "Session am %s" (Utils_time.formatted_date_time start)
+  | SessionIndent -> "Einrückungen groupieren Folgesessions."
   | SessionReminderDefaultLeadTime leadtime ->
     Format.asprintf
       "Die Standardvorlaufzeit dieses Experiments ist: %s"
@@ -73,7 +74,6 @@ let to_string = function
       "Der Standarderinnerungsbetreff dieses Experiments ist:\n %s"
       text
   | SessionReminder -> "Sessionerinnerung"
-  | SessionIndent -> "Einrückungen groupieren Folgesessions."
   | SessionRegistrationTitle -> "Für diese Session anmelden"
   | SignUpAcceptTermsAndConditions -> "Ich akzeptiere die Nutzungsbedingungen."
   | SignUpCTA -> "Jetzt anmelden und an Experimenten teilnehmen."
@@ -221,6 +221,9 @@ let hint_to_string = function
      Sprache hier."
   | SessionRegistrationHint ->
     "Die Registrierung für eine Session ist verbindlich."
+  | SessionRegistrationFollowUpHint ->
+    "Die Registrierung für eine Session inlk. allen Folgesessions ist \
+     verbindlich."
   | SelectedDateIsPast -> "Das gewählte Datum liegt in der Vergangenheit."
   | SignUpForWaitingList ->
     "Das Rekrutierungsteam wird sich mit Ihnen in Verbindung setzen, um Ihnen \

--- a/pool/app/pool_common/locales/i18n_en.ml
+++ b/pool/app/pool_common/locales/i18n_en.ml
@@ -10,7 +10,8 @@ let to_string = function
     Format.asprintf
       "Currently, there are no %s available."
       (Locales_en.field_to_string field)
-  | ExperimentContactEnrolledNote -> "You signed up for the following session:"
+  | ExperimentContactEnrolledNote ->
+    "You signed up for the following session(s):"
   | ExperimentNewTitle -> "Create new experiment"
   | ExperimentListTitle -> "Experiments"
   | ExperimentListEmpty ->
@@ -57,6 +58,7 @@ let to_string = function
   | SentInvitations -> "Sent invitations"
   | SessionDetailTitle start ->
     Format.asprintf "Session at %s" (Utils_time.formatted_date_time start)
+  | SessionIndent -> "Indentations group follow-up sessions."
   | SessionReminderDefaultLeadTime leadtime ->
     Format.asprintf
       "The experiment default lead time is: %s"
@@ -66,7 +68,6 @@ let to_string = function
   | SessionReminderDefaultSubject text ->
     Format.asprintf "The experiment default subject is:\n\n %s" text
   | SessionReminder -> "Session reminder"
-  | SessionIndent -> "Indentations group follow-up sessions."
   | SessionRegistrationTitle -> "Register for this session"
   | SignUpAcceptTermsAndConditions -> "I accept the terms and conditions."
   | SignUpCTA -> "Register now to participate in economic experiments."
@@ -211,6 +212,8 @@ let hint_to_string = function
   | SessionReminderLanguageHint ->
     "If you provide a custom reminder text, select its language here."
   | SessionRegistrationHint -> "The registration for a session is binding."
+  | SessionRegistrationFollowUpHint ->
+    "The registration for a session incl. all follow up sessions is binding."
   | SignUpForWaitingList ->
     "The recruitment team will contact you, to assign you to a session, if \
      there is a free place."

--- a/pool/app/pool_common/locales/locales_de.ml
+++ b/pool/app/pool_common/locales/locales_de.ml
@@ -347,7 +347,12 @@ let rec error_to_string = function
       (field_to_string f2)
   | ReadOnlyModel -> "Model ausschliesslich um von der Datenbank zu lesen!"
   | RegistrationDisabled -> "Registrierung ist deaktiviert."
+  | ReminderSubjectAndTextRequired ->
+    "Bitte geben Sie sowohl den Betreff als auch den Text für die Session \
+     Erinnerung an."
   | RequestRequiredFields -> "Bitte alle notwendigen Felder ausfüllen."
+  | RequiredFieldsMissing ->
+    "Bitte beantworten Sie die folgenden Fragen um fortzufahren."
   | Retrieve field ->
     field_message "" (field_to_string field) "konnte nicht gefunden werden."
   | SessionHasAssignments ->
@@ -355,11 +360,7 @@ let rec error_to_string = function
      gelöscht werden."
   | SessionFullyBooked -> "Session ist ausgebucht"
   | SessionInvalid -> "Ungültige Session, bitte erneut einloggen."
-  | ReminderSubjectAndTextRequired ->
-    "Bitte geben Sie sowohl den Betreff als auch den Text für die Session \
-     Erinnerung an."
-  | RequiredFieldsMissing ->
-    "Bitte beantworten Sie die folgenden Fragen um fortzufahren."
+  | SessionRegistrationViaParent -> "Einschreibung via Hauptsession."
   | SessionTenantNotFound ->
     "Auf unserer Seite ist etwas schief gegangen, bitte später nochmals  \
      versuchen. Falls der Fehler mehrmals auftritt, bitte den Adminstrator  \

--- a/pool/app/pool_common/locales/locales_en.ml
+++ b/pool/app/pool_common/locales/locales_en.ml
@@ -326,22 +326,23 @@ let rec error_to_string = function
       (field_to_string f2)
   | ReadOnlyModel -> "Read only model!"
   | RegistrationDisabled -> "registration is disabled."
+  | ReminderSubjectAndTextRequired ->
+    "Please enter both a subject and a text for the session reminder."
   | RequestRequiredFields -> "Please provide necessary fields"
+  | RequiredFieldsMissing ->
+    "To continue, you need to answer the following questions."
   | Retrieve field -> field_message "Cannot retrieve" (field_to_string field) ""
   | SessionHasAssignments ->
     "There are already assignments for this session. It cannot be deleted."
   | SessionFullyBooked -> "Session is fully booked"
   | SessionInvalid -> "Invalid session, please login."
-  | ReminderSubjectAndTextRequired ->
-    "Please enter both a subject and a text for the session reminder."
-  | RequiredFieldsMissing ->
-    "To continue, you need to answer the following questions."
   | SessionAlreadyCanceled date ->
     CCFormat.asprintf "This session has already been canceled on %s." date
   | SessionAlreadyClosed date ->
     CCFormat.asprintf "This session has already been closed at %s." date
   | SessionInPast -> "This session has already finished."
   | SessionNotStarted -> "This session cannot be closed, yet."
+  | SessionRegistrationViaParent -> "Registration via main session."
   | SessionTenantNotFound ->
     "Something on our side went wrong, please try again later or on multi  \
      occurrences please contact the Administrator."

--- a/pool/app/session/session.mli
+++ b/pool/app/session/session.mli
@@ -134,8 +134,10 @@ module Public : sig
   val pp : Format.formatter -> t -> unit
   val show : t -> string
   val is_fully_booked : t -> bool
+  val group_and_sort : t list -> (t * t list) list
 end
 
+val to_public : t -> Public.t
 val group_and_sort : t list -> (t * t list) list
 val is_cancellable : t -> (unit, Pool_common.Message.error) result
 val is_closable : t -> (unit, Pool_common.Message.error) result

--- a/pool/cqrs_command/assignment_command.ml
+++ b/pool/cqrs_command/assignment_command.ml
@@ -47,7 +47,7 @@ end = struct
         | true -> Error Pool_common.Message.(DirectRegistrationIsDisabled)
         | false -> Ok ()
       in
-      let* _ =
+      let* () =
         Session.Public.is_fully_booked command.session
         |> function
         | true -> Error Pool_common.Message.(SessionFullyBooked)

--- a/pool/database/seed/seed_session.ml
+++ b/pool/database/seed/seed_session.ml
@@ -101,9 +101,9 @@ let create pool =
                 |> CCOption.get_exn_or "Invalid time")
           ; duration = Duration.create halfhour |> get_or_failwith
           ; description = Some "MRI Study" >>= Description.create %> of_result
-          ; max_participants = ParticipantAmount.create 10 |> get_or_failwith
-          ; min_participants = ParticipantAmount.create 2 |> get_or_failwith
-          ; overbook = ParticipantAmount.create 3 |> get_or_failwith
+          ; max_participants = parent.max_participants
+          ; min_participants = parent.min_participants
+          ; overbook = parent.overbook
           ; reminder_lead_time = None
           ; reminder_subject = None
           ; reminder_text = None

--- a/pool/web/handler/admin_experiments_assignments.ml
+++ b/pool/web/handler/admin_experiments_assignments.ml
@@ -18,6 +18,9 @@ let index req =
     @@ let* experiment = Experiment.find database_label id in
        let* sessions =
          Session.find_all_for_experiment database_label experiment.Experiment.id
+         >|+ Session.group_and_sort
+         >|+ CCList.flat_map (fun (session, follow_ups) ->
+               session :: follow_ups)
        in
        let* assignments =
          Lwt_list.map_s

--- a/pool/web/handler/admin_experiments_waiting_list.ml
+++ b/pool/web/handler/admin_experiments_waiting_list.ml
@@ -40,6 +40,7 @@ let detail req =
     @@ let* waiting_list = Waiting_list.find database_label id in
        let* sessions =
          Session.find_all_for_experiment database_label experiment_id
+         >|+ Session.group_and_sort
        in
        let flash_fetcher key = Sihl.Web.Flash.find key req in
        Page.Admin.WaitingList.detail

--- a/pool/web/handler/admin_experiments_waiting_list.ml
+++ b/pool/web/handler/admin_experiments_waiting_list.ml
@@ -130,7 +130,8 @@ let assign_contact req =
            database_label
            experiment_id
            waiting_list.Waiting_list.contact
-         ||> CCOption.is_some
+         ||> CCList.is_empty
+         ||> not
        in
        let* language =
          let* default = Settings.default_language database_label in

--- a/pool/web/handler/contact_session.ml
+++ b/pool/web/handler/contact_session.ml
@@ -24,12 +24,20 @@ let show req =
            experiment.Experiment.Public.id
            contact
          >|> function
-         | Some _ ->
+         | [] -> Lwt.return_ok ()
+         | _ ->
            Lwt.return_error Pool_common.Message.AlreadySignedUpForExperiment
-         | None -> Lwt.return_ok ()
        in
        let* session = Session.find_public database_label id in
-       Page.Contact.Experiment.Assignment.detail session experiment context
+       let* follow_ups =
+         Session.find_follow_ups database_label id
+         >|+ CCList.map Session.to_public
+       in
+       Page.Contact.Experiment.Assignment.detail
+         session
+         follow_ups
+         experiment
+         context
        |> Lwt.return_ok
        >>= create_layout req context
        >|+ Sihl.Web.Response.of_html

--- a/pool/web/view/page/page_admin_assignments.ml
+++ b/pool/web/view/page/page_admin_assignments.ml
@@ -94,10 +94,22 @@ let list assignments experiment (Pool_context.{ language; _ } as context) =
   let html =
     CCList.map
       (fun (session, assignments) ->
+        let attrs, to_title =
+          if CCOption.is_some session.Session.follow_up_to
+          then
+            ( [ a_class [ "inset"; "left" ] ]
+            , fun session ->
+                Format.asprintf
+                  "%s (%s)"
+                  (session |> Session.session_date_to_human)
+                  (Pool_common.Utils.field_to_string
+                     language
+                     Field.FollowUpSession) )
+          else [], Session.session_date_to_human
+        in
         div
-          [ h3
-              ~a:[ a_class [ "heading-3" ] ]
-              [ txt (session |> Session.session_date_to_human) ]
+          ~a:attrs
+          [ h3 ~a:[ a_class [ "heading-3" ] ] [ txt (session |> to_title) ]
           ; Partials.overview_list
               context
               experiment.Experiment.id

--- a/pool/web/view/page/page_contact_assignment.ml
+++ b/pool/web/view/page/page_contact_assignment.ml
@@ -1,43 +1,44 @@
 open Tyxml.Html
 open Component.Input
 
-let detail session experiment Pool_context.{ language; csrf; _ } =
+let detail session follow_ups experiment Pool_context.{ language; csrf; _ } =
+  let open Pool_common in
   let form_action =
     Format.asprintf
       "/experiments/%s/sessions/%s"
       (experiment.Experiment.Public.id |> Experiment.Id.value)
-      (session.Session.Public.id |> Pool_common.Id.value)
+      (session.Session.Public.id |> Id.value)
     |> Sihl.Web.externalize_path
   in
   div
     ~a:[ a_class [ "trim"; "narrow"; "safety-margin" ] ]
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
-        [ txt
-            Pool_common.(
-              Utils.text_to_string language I18n.SessionRegistrationTitle)
-        ]
+        [ txt (Utils.text_to_string language I18n.SessionRegistrationTitle) ]
     ; div
         ~a:[ a_class [ "stack" ] ]
-        [ Page_contact_sessions.public_detail session language
-        ; p
-            Pool_common.
-              [ Utils.hint_to_string language I18n.SessionRegistrationHint
+        (Page_contact_sessions.public_detail language (session :: follow_ups)
+        @ [ p
+              [ Utils.hint_to_string
+                  language
+                  (if CCList.is_empty follow_ups
+                  then I18n.SessionRegistrationHint
+                  else I18n.SessionRegistrationFollowUpHint)
                 |> txt
               ]
-        ; form
-            ~a:[ a_action form_action; a_method `Post ]
-            [ csrf_element csrf ()
-            ; div
-                ~a:[ a_class [ "flexrow" ] ]
-                [ submit_element
-                    ~classnames:[ "push" ]
-                    language
-                    Pool_common.Message.Register
-                    ~submit_type:`Primary
-                    ()
-                ]
-            ]
-        ]
+          ; form
+              ~a:[ a_action form_action; a_method `Post ]
+              [ csrf_element csrf ()
+              ; div
+                  ~a:[ a_class [ "flexrow" ] ]
+                  [ submit_element
+                      ~classnames:[ "push" ]
+                      language
+                      Message.Register
+                      ~submit_type:`Primary
+                      ()
+                  ]
+              ]
+          ])
     ]
 ;;


### PR DESCRIPTION
- Signup for follow up sessions as well
- show follow up sessions in contact experiment view
- hide "registration" only for follow up sessions
