### PR TITLE
Feature/135 email language fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - add language parameter to email links
 - improve consistency (schedule, queue worker, matcher)
 
+### Changed
+
+- message_template does not fall back to global template, if a language of entity specific templates is missing.
+
 ## [0.1.1](https://github.com/uzh/pool/tree/0.1.1) - 2023-02-02
 
 ### Added

--- a/pool/app/message_template/message_template.ml
+++ b/pool/app/message_template/message_template.ml
@@ -70,9 +70,9 @@ module AssignmentConfirmation = struct
     find_by_label_to_send pool language Label.AssignmentConfirmation
   ;;
 
-  let create pool language tenant session contact =
+  let create pool preferred_language tenant session contact =
     let open Utils.Lwt_result.Infix in
-    let* template, language = template pool language in
+    let* template, language = template pool preferred_language in
     let params = email_params language session contact in
     let layout = layout_from_tenant tenant in
     let email = contact |> Contact.email_address in
@@ -81,9 +81,9 @@ module AssignmentConfirmation = struct
     |> Lwt_result.return
   ;;
 
-  let create_from_public_session pool language tenant session contact =
+  let create_from_public_session pool preferred_language tenant session contact =
     let open Utils.Lwt_result.Infix in
-    let* template, language = template pool language in
+    let* template, language = template pool preferred_language in
     let params = email_params_public_session language session contact in
     let layout = layout_from_tenant tenant in
     let email = contact |> Contact.email_address in
@@ -104,11 +104,13 @@ module ContactRegistrationAttempt = struct
       ]
   ;;
 
-  let create pool language tenant contact =
-    let open Message_utils in
+  let create pool preferred_language tenant contact =
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      find_by_label_to_send pool language Label.ContactRegistrationAttempt
+      find_by_label_to_send
+        pool
+        preferred_language
+        Label.ContactRegistrationAttempt
     in
     let layout = layout_from_tenant tenant in
     let tenant_url = tenant.Pool_tenant.url in
@@ -129,11 +131,10 @@ module EmailVerification = struct
     global_params contact.Contact.user @ [ "verificationUrl", validation_url ]
   ;;
 
-  let create pool language layout contact email_address token =
-    let open Message_utils in
+  let create pool preferred_language layout contact email_address token =
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      find_by_label_to_send pool language Label.EmailVerification
+      find_by_label_to_send pool preferred_language Label.EmailVerification
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let validation_url =
@@ -471,11 +472,18 @@ module SignUpVerification = struct
     ]
   ;;
 
-  let create pool language tenant email_address token firstname lastname =
-    let open Message_utils in
+  let create
+    pool
+    preferred_language
+    tenant
+    email_address
+    token
+    firstname
+    lastname
+    =
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      find_by_label_to_send pool language Label.SignUpVerification
+      find_by_label_to_send pool preferred_language Label.SignUpVerification
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in

--- a/pool/app/message_template/message_template.ml
+++ b/pool/app/message_template/message_template.ml
@@ -204,11 +204,14 @@ module ExperimentInvitation = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let%lwt system_languages = Settings.find_languages database_label in
-    let* language =
-      message_langauge system_languages contact |> Lwt_result.lift
+    let* preferred_langauge =
+      preferred_language system_languages contact |> Lwt_result.lift
     in
     let* template, language =
-      find_by_label_to_send pool preferred_langauge Label.ExperimentInvitation
+      find_by_label_to_send
+        database_label
+        preferred_langauge
+        Label.ExperimentInvitation
     in
     let%lwt tenant_url = Pool_tenant.Url.of_pool database_label in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool database_label in
@@ -247,7 +250,6 @@ module PasswordReset = struct
   ;;
 
   let create pool preferred_language layout user =
-    let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let email = Pool_user.user_email_address user in
     let* template, language =
@@ -364,7 +366,7 @@ module SessionReminder = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* preferred_language =
-      message_langauge system_languages contact |> Lwt_result.lift
+      preferred_language system_languages contact |> Lwt_result.lift
     in
     let* template, language =
       find_by_label_to_send

--- a/pool/app/message_template/message_template.ml
+++ b/pool/app/message_template/message_template.ml
@@ -8,6 +8,8 @@ let src = Logs.Src.create "message_template"
 let find = Repo.find
 let all_default = Repo.all_default
 let find_all_of_entity_by_label = Repo.find_all_of_entity_by_label
+let find_by_label_to_send = Repo.find_by_label_to_send
+let find_all_by_label_to_send = Repo.find_all_by_label_to_send
 
 let filter_languages languages templates =
   languages
@@ -65,7 +67,7 @@ module AssignmentConfirmation = struct
   ;;
 
   let template pool language =
-    Repo.find_by_label pool language Label.AssignmentConfirmation
+    find_by_label_to_send pool language Label.AssignmentConfirmation
   ;;
 
   let create pool language tenant session contact =
@@ -106,7 +108,7 @@ module ContactRegistrationAttempt = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      Repo.find_by_label pool language Label.ContactRegistrationAttempt
+      find_by_label_to_send pool language Label.ContactRegistrationAttempt
     in
     let layout = layout_from_tenant tenant in
     let tenant_url = tenant.Pool_tenant.url in
@@ -131,7 +133,7 @@ module EmailVerification = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      Repo.find_by_label pool language Label.EmailVerification
+      find_by_label_to_send pool language Label.EmailVerification
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let validation_url =
@@ -171,7 +173,7 @@ module ExperimentInvitation = struct
     let pool = tenant.Pool_tenant.database_label in
     let%lwt sys_langs = Settings.find_languages pool in
     let* templates =
-      Repo.find_all_by_label
+      find_all_by_label_to_send
         pool
         ~entity_uuids:[ Experiment.(Id.to_common experiment.Experiment.id) ]
         sys_langs
@@ -205,8 +207,8 @@ module ExperimentInvitation = struct
     let* language =
       message_langauge system_languages contact |> Lwt_result.lift
     in
-    let* template =
-      Repo.find_by_label database_label language Label.ExperimentInvitation
+    let* template, language =
+      find_by_label_to_send pool preferred_langauge Label.ExperimentInvitation
     in
     let%lwt tenant_url = Pool_tenant.Url.of_pool database_label in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool database_label in
@@ -229,7 +231,7 @@ module PasswordChange = struct
   let create pool preferred_langauge tenant user =
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      Repo.find_by_label pool preferred_langauge Label.PasswordChange
+      find_by_label_to_send pool preferred_langauge Label.PasswordChange
     in
     let layout = layout_from_tenant tenant in
     let email = Pool_user.user_email_address user in
@@ -249,7 +251,7 @@ module PasswordReset = struct
     let open Utils.Lwt_result.Infix in
     let email = Pool_user.user_email_address user in
     let* template, language =
-      Repo.find_by_label pool preferred_language Label.PasswordReset
+      find_by_label_to_send pool preferred_language Label.PasswordReset
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in
@@ -298,7 +300,7 @@ module ProfileUpdateTrigger = struct
     let open Utils.Lwt_result.Infix in
     let%lwt sys_langs = Settings.find_languages pool in
     let* templates =
-      Repo.find_all_by_label pool sys_langs Label.SessionReschedule
+      find_all_by_label_to_send pool sys_langs Label.SessionReschedule
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in
@@ -330,7 +332,7 @@ module SessionCancellation = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* templates =
-      Repo.find_all_by_label pool sys_langs Label.SessionCancellation
+      find_all_by_label_to_send pool sys_langs Label.SessionCancellation
     in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in
     let layout = layout_from_tenant tenant in
@@ -365,7 +367,7 @@ module SessionReminder = struct
       message_langauge system_languages contact |> Lwt_result.lift
     in
     let* template, language =
-      Repo.find_by_label
+      find_by_label_to_send
         ~entity_uuids:
           [ session.Session.id
           ; Experiment.(Id.to_common experiment.Experiment.id)
@@ -391,7 +393,7 @@ module SessionReminder = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* templates =
-      Repo.find_all_by_label
+      find_all_by_label_to_send
         ~entity_uuids:
           [ session.Session.id
           ; Experiment.(Id.to_common experiment.Experiment.id)
@@ -434,7 +436,7 @@ module SessionReschedule = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* templates =
-      Repo.find_all_by_label pool sys_langs Label.SessionReschedule
+      find_all_by_label_to_send pool sys_langs Label.SessionReschedule
     in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in
     let layout = layout_from_tenant tenant in
@@ -471,7 +473,7 @@ module SignUpVerification = struct
     let open Message_utils in
     let open Utils.Lwt_result.Infix in
     let* template, language =
-      Repo.find_by_label pool language Label.SignUpVerification
+      find_by_label_to_send pool language Label.SignUpVerification
     in
     let%lwt url = Pool_tenant.Url.of_pool pool in
     let%lwt sender = Pool_tenant.Service.Email.sender_of_pool pool in

--- a/pool/app/message_template/message_template.mli
+++ b/pool/app/message_template/message_template.mli
@@ -91,6 +91,20 @@ val find_all_of_entity_by_label
   -> Label.t
   -> t list Lwt.t
 
+val find_by_label_to_send
+  :  Pool_database.Label.t
+  -> ?entity_uuids:Pool_common.Id.t list
+  -> Pool_common.Language.t
+  -> Label.t
+  -> (t * Pool_common.Language.t, Pool_common.Message.error) result Lwt.t
+
+val find_all_by_label_to_send
+  :  Pool_database.Label.t
+  -> ?entity_uuids:Pool_common.Id.t list
+  -> Pool_common.Language.t list
+  -> Label.t
+  -> (t list, Pool_common.Message.error) Lwt_result.t
+
 val filter_languages
   :  Pool_common.Language.t list
   -> t list

--- a/pool/app/message_template/message_template.mli
+++ b/pool/app/message_template/message_template.mli
@@ -96,7 +96,7 @@ val find_by_label_to_send
   -> ?entity_uuids:Pool_common.Id.t list
   -> Pool_common.Language.t
   -> Label.t
-  -> (t * Pool_common.Language.t, Pool_common.Message.error) result Lwt.t
+  -> (t * Pool_common.Language.t, Pool_common.Message.error) Lwt_result.t
 
 val find_all_by_label_to_send
   :  Pool_database.Label.t

--- a/pool/app/message_template/message_utils.ml
+++ b/pool/app/message_template/message_utils.ml
@@ -162,7 +162,7 @@ let search_by_language templates lang =
     templates
   |> (function
        | None -> templates |> CCList.head_opt
-       | Some template -> CCOption.pure template)
+       | Some template -> Some template)
   |> CCOption.map (fun ({ language; _ } as t) -> language, t)
   |> CCOption.to_result (Message.NotFound Field.MessageTemplate)
 ;;

--- a/pool/app/message_template/message_utils.ml
+++ b/pool/app/message_template/message_utils.ml
@@ -140,7 +140,7 @@ let combine_html language html_title =
   |> html_to_string
 ;;
 
-let message_langauge sys (contact : Contact.t) =
+let preferred_language sys (contact : Contact.t) =
   let open Pool_common in
   let open CCResult in
   let* default =
@@ -169,6 +169,6 @@ let search_by_language templates lang =
 
 let template_by_contact sys_langs templates contact =
   let open CCResult in
-  let* preferred_language = message_langauge sys_langs contact in
+  let* preferred_language = preferred_language sys_langs contact in
   search_by_language templates preferred_language
 ;;

--- a/pool/app/message_template/repo/repo.ml
+++ b/pool/app/message_template/repo/repo.ml
@@ -3,8 +3,8 @@ include Repo_entity
 let insert = Repo_sql.insert
 let update = Repo_sql.update
 let find = Repo_sql.find
-let find_by_label = Repo_sql.find_by_label
-let find_all_by_label = Repo_sql.find_all_by_label
+let find_by_label_to_send = Repo_sql.find_by_label_to_send
+let find_all_by_label_to_send = Repo_sql.find_all_by_label_to_send
 let all_default = Repo_sql.all_default
 let find_all_of_entity_by_label = Repo_sql.find_all_of_entity_by_label
 let insert_default_if_not_exists = Repo_sql.insert_default_if_not_exists

--- a/pool/app/message_template/repo/repo.ml
+++ b/pool/app/message_template/repo/repo.ml
@@ -4,6 +4,7 @@ let insert = Repo_sql.insert
 let update = Repo_sql.update
 let find = Repo_sql.find
 let find_by_label = Repo_sql.find_by_label
+let find_all_by_label = Repo_sql.find_all_by_label
 let all_default = Repo_sql.all_default
 let find_all_of_entity_by_label = Repo_sql.find_all_of_entity_by_label
 let insert_default_if_not_exists = Repo_sql.insert_default_if_not_exists

--- a/pool/app/message_template/repo/repo_sql.ml
+++ b/pool/app/message_template/repo/repo_sql.ml
@@ -81,7 +81,7 @@ let update pool t =
 
 (* The template are prioritised according to the entity_uuids list, from left to
    right. If none are found, the default template will be returned. *)
-let find_by_label pool ?entity_uuids language label =
+let find_by_label_to_send pool ?entity_uuids language label =
   let open Utils.Lwt_result.Infix in
   let open Caqti_request.Infix in
   let where =
@@ -174,13 +174,13 @@ let find_all_by_entity_uuid_and_label_request dyn languages =
         base )
 ;;
 
-let find_all_by_label pool ?entity_uuids languages label =
+let find_all_by_label_to_send pool ?entity_uuids languages label =
   if CCList.is_empty languages
   then Lwt_result.return []
   else
     let open Utils.Lwt_result.Infix in
     let open Caqti_request.Infix in
-    find_by_label pool ?entity_uuids Pool_common.Language.En label
+    find_by_label_to_send pool ?entity_uuids Pool_common.Language.En label
     |>> fun ({ entity_uuid; _ }, _) ->
     let dyn = Dynparam.(empty |> add Caqti_type.string (Label.show label)) in
     let dyn, sql =
@@ -250,7 +250,7 @@ let find pool id =
 
 let insert_default_if_not_exists pool t =
   let open Utils.Lwt_result.Infix in
-  find_by_label pool t.Entity.language t.Entity.label
+  find_by_label_to_send pool t.Entity.language t.Entity.label
   ||> CCResult.to_opt
   >|> function
   | None -> insert pool t

--- a/pool/app/message_template/repo/repo_sql.ml
+++ b/pool/app/message_template/repo/repo_sql.ml
@@ -161,15 +161,16 @@ let find_all_by_entity_uuid_and_label_request dyn languages =
     , dyn )
   in
   let base =
-    Format.asprintf "%s WHERE label = ? AND %s" select_sql languages_sql
+    Format.asprintf "%s WHERE label = ? AND %s " select_sql languages_sql
   in
   function
   | None ->
-    dyn, Format.asprintf "%s pool_message_templates.entity_uuid IS NULL" base
+    ( dyn
+    , Format.asprintf "%s AND pool_message_templates.entity_uuid IS NULL" base )
   | Some id ->
     ( dyn |> Dynparam.add Pool_common.Repo.Id.t id
     , Format.asprintf
-        "%s pool_message_templates.entity_uuid = UNHEX(REPLACE(?, '-', ''))"
+        "%s AND pool_message_templates.entity_uuid = UNHEX(REPLACE(?, '-', ''))"
         base )
 ;;
 

--- a/pool/app/message_template/repo/repo_sql.ml
+++ b/pool/app/message_template/repo/repo_sql.ml
@@ -85,23 +85,24 @@ let find_by_label pool ?entity_uuids language label =
   let open Utils.Lwt_result.Infix in
   let open Caqti_request.Infix in
   let where =
-    Format.asprintf
-      {sql|
+    Format.asprintf {sql|
     pool_message_templates.label = $1
-    AND pool_message_templates.language = $2
     %s
     |sql}
   in
+  let order_by_lang = {| FIELD(pool_message_templates.language, $2) DESC |} in
   let dyn =
     Dynparam.(
       empty
       |> add Caqti_type.string (Label.show label)
       |> add Caqti_type.string (Pool_common.Language.show language))
   in
-  let where, dyn =
+  let where, order_by, dyn =
     match entity_uuids with
     | None | Some [] ->
-      where {sql| AND pool_message_templates.entity_uuid IS NULL |sql}, dyn
+      ( where {sql| AND pool_message_templates.entity_uuid IS NULL |sql}
+      , order_by_lang
+      , dyn )
     | Some entity_uuids ->
       let id_list, dyn =
         CCList.foldi
@@ -115,29 +116,78 @@ let find_by_label pool ?entity_uuids language label =
           ([], dyn)
           entity_uuids
       in
-      id_list
-      |> CCString.concat ","
-      |> fun ids ->
+      let ids = id_list |> CCString.concat "," in
+      let order_by =
+        Format.asprintf
+          {|
+        FIELD(entity_uuid, %s) DESC,
+        %s
+        |}
+          ids
+          order_by_lang
+      in
       ( Format.asprintf
           {sql| AND(
-                  pool_message_templates.entity_uuid IS NULL
-                  OR
-                  pool_message_templates.entity_uuid IN (%s))
-                ORDER BY
-                FIELD(entity_uuid, %s) DESC
-                LIMIT 1
-              |sql}
-          ids
+              pool_message_templates.entity_uuid IS NULL
+              OR
+              pool_message_templates.entity_uuid IN (%s))
+          |sql}
           ids
         |> where
+      , order_by
       , dyn )
   in
   let (Dynparam.Pack (pt, pv)) = dyn in
   let request =
-    Format.asprintf "%s WHERE %s" select_sql where |> pt ->! RepoEntity.t
+    Format.asprintf "%s WHERE %s ORDER BY %s LIMIT 1" select_sql where order_by
+    |> pt ->! RepoEntity.t
   in
   Utils.Database.find_opt (pool |> Database.Label.value) request pv
   ||> CCOption.to_result Pool_common.Message.(NotFound Field.Template)
+  >|+ fun ({ language; _ } as t) -> t, language
+;;
+
+let find_all_by_entity_uuid_and_label_request dyn languages =
+  let languages_sql, dyn =
+    CCList.fold_left
+      (fun (params, dyn) lang ->
+        "?" :: params, dyn |> Dynparam.add Pool_common.Repo.Language.t lang)
+      ([], dyn)
+      languages
+    |> fun (params, dyn) ->
+    ( params
+      |> CCString.concat ","
+      |> Format.asprintf "pool_message_templates.language IN (%s)"
+    , dyn )
+  in
+  let base =
+    Format.asprintf "%s WHERE label = ? AND %s" select_sql languages_sql
+  in
+  function
+  | None ->
+    dyn, Format.asprintf "%s pool_message_templates.entity_uuid IS NULL" base
+  | Some id ->
+    ( dyn |> Dynparam.add Pool_common.Repo.Id.t id
+    , Format.asprintf
+        "%s pool_message_templates.entity_uuid = UNHEX(REPLACE(?, '-', ''))"
+        base )
+;;
+
+let find_all_by_label pool ?entity_uuids languages label =
+  if CCList.is_empty languages
+  then Lwt_result.return []
+  else
+    let open Utils.Lwt_result.Infix in
+    let open Caqti_request.Infix in
+    find_by_label pool ?entity_uuids Pool_common.Language.En label
+    |>> fun ({ entity_uuid; _ }, _) ->
+    let dyn = Dynparam.(empty |> add Caqti_type.string (Label.show label)) in
+    let dyn, sql =
+      find_all_by_entity_uuid_and_label_request dyn languages entity_uuid
+    in
+    let (Dynparam.Pack (pt, pv)) = dyn in
+    let request = sql |> pt ->! RepoEntity.t in
+    Utils.Database.collect (pool |> Database.Label.value) request pv
 ;;
 
 let find_all_default_request =

--- a/pool/app/pool_common/entity_i18n.ml
+++ b/pool/app/pool_common/entity_i18n.ml
@@ -127,6 +127,8 @@ type hint =
   | LocationFiles
   | Locations
   | LocationSessions
+  | MissingMessageTemplates of string * string list (* TODO[timhub]*)
+  (* | MissingMessageTemplates of string * Entity.Language.t list *)
   | NumberIsDaysHint
   | NumberIsSecondsHint
   | NumberIsWeeksHint

--- a/pool/app/pool_common/entity_i18n.ml
+++ b/pool/app/pool_common/entity_i18n.ml
@@ -127,8 +127,7 @@ type hint =
   | LocationFiles
   | Locations
   | LocationSessions
-  | MissingMessageTemplates of string * string list (* TODO[timhub]*)
-  (* | MissingMessageTemplates of string * Entity.Language.t list *)
+  | MissingMessageTemplates of string * string list
   | NumberIsDaysHint
   | NumberIsSecondsHint
   | NumberIsWeeksHint

--- a/pool/app/pool_common/locales/i18n_de.ml
+++ b/pool/app/pool_common/locales/i18n_de.ml
@@ -214,6 +214,11 @@ let rec hint_to_string = function
     "Definieren Sie die Kriterien, anhand welchen Kontakte an dieses \
      Experiment eingeladen werden."
   | I18nText str -> str
+  | MissingMessageTemplates (label, languages) ->
+    Format.asprintf
+      "Das '%s' Template fehlt in den folgenden Sprachen: %s"
+      label
+      (languages |> CCString.concat ", ")
   | LocationFiles ->
     "Zusatzinformationen zum Standort, wie z.B. eine Wegbeschreibung. \
      Kontakte, die an einer Session an diesem Standort teilnehmen, können auf \

--- a/pool/app/pool_common/locales/i18n_en.ml
+++ b/pool/app/pool_common/locales/i18n_en.ml
@@ -214,6 +214,11 @@ let rec hint_to_string = function
     "Locations, where experiments are conducted. Every session has to have a \
      location."
   | I18nText str -> str
+  | MissingMessageTemplates (label, languages) ->
+    Format.asprintf
+      "The '%s' template is missing is the following languages: %s"
+      label
+      (languages |> CCString.concat ", ")
   | NumberIsSecondsHint -> "Nr. of seconds"
   | NumberIsDaysHint -> "Nr. of days"
   | NumberIsWeeksHint -> "Nr. of weeks"

--- a/pool/test/integration.ml
+++ b/pool/test/integration.ml
@@ -117,6 +117,17 @@ let suite =
               `Slow
               should_not_send_registration_notification
           ] )
+    ; ( "message_template"
+      , Message_template_test.
+          [ test_case
+              "get template with language missing"
+              `Slow
+              get_template_with_language_missing
+          ; test_case
+              "get templates in multiple languages"
+              `Slow
+              get_templates_in_multile_languages
+          ] )
     ; "cleanup", [ test_case "clean up test database" `Quick Seed.cleanup ]
     ]
 ;;

--- a/pool/test/message_template_test.ml
+++ b/pool/test/message_template_test.ml
@@ -90,6 +90,7 @@ let create_invitation language ?entity_uuid () =
 ;;
 
 let get_template_with_language_missing _ () =
+  let open Utils.Lwt_result.Infix in
   let%lwt () =
     let database_label = Test_utils.Data.database_label in
     let label = Message_template.Label.ExperimentInvitation in
@@ -109,8 +110,8 @@ let get_template_with_language_missing _ () =
              ~entity_uuids:Experiment.[ experiment.id |> Id.to_common ]
              lang
              label
-           |> Lwt.map CCResult.get_exn
-           |> Lwt.map fst)
+           ||> CCResult.get_exn
+           ||> fst)
     in
     (* When one entity specific template exists, expect this to be returned
        every time *)
@@ -122,6 +123,7 @@ let get_template_with_language_missing _ () =
 ;;
 
 let get_templates_in_multile_languages _ () =
+  let open Utils.Lwt_result.Infix in
   let%lwt () =
     let database_label = Test_utils.Data.database_label in
     let label = Message_template.Label.ExperimentInvitation in
@@ -143,8 +145,8 @@ let get_templates_in_multile_languages _ () =
              ~entity_uuids:Experiment.[ experiment.id |> Id.to_common ]
              lang
              label
-           |> Lwt.map CCResult.get_exn
-           |> Lwt.map fst)
+           ||> CCResult.get_exn
+           ||> fst)
     in
     (* Expect all created templates to be returned *)
     Alcotest.(check (list Test_utils.message_template) "succeeds" templates res)

--- a/pool/test/message_template_test.ml
+++ b/pool/test/message_template_test.ml
@@ -63,3 +63,92 @@ let create_with_unavailable_language () =
   let expected = Error Pool_common.Message.(Invalid Field.Language) in
   test_create available_languages expected
 ;;
+
+(* Integration tests *)
+
+let create_experiment () =
+  let database_label = Test_utils.Data.database_label in
+  let experiment = Test_utils.Model.create_experiment () in
+  let%lwt () =
+    [ Experiment.Created experiment |> Pool_event.experiment ]
+    |> Pool_event.handle_events database_label
+  in
+  Lwt.return experiment
+;;
+
+let create_invitation language ?entity_uuid () =
+  let database_label = Test_utils.Data.database_label in
+  let label = Message_template.Label.ExperimentInvitation in
+  let template =
+    Test_utils.Model.create_message_template ~label ~language ?entity_uuid ()
+  in
+  let%lwt () =
+    [ Message_template.Created template |> Pool_event.message_template ]
+    |> Pool_event.handle_events database_label
+  in
+  Lwt.return template
+;;
+
+let get_template_with_language_missing _ () =
+  let%lwt () =
+    let database_label = Test_utils.Data.database_label in
+    let label = Message_template.Label.ExperimentInvitation in
+    let%lwt experiment = create_experiment () in
+    let template_language = Pool_common.Language.En in
+    let%lwt template =
+      create_invitation
+        template_language
+        ~entity_uuid:Experiment.(experiment.id |> Id.to_common)
+        ()
+    in
+    let%lwt res =
+      Pool_common.Language.[ De; En ]
+      |> Lwt_list.map_s (fun lang ->
+           Message_template.find_by_label_to_send
+             database_label
+             ~entity_uuids:Experiment.[ experiment.id |> Id.to_common ]
+             lang
+             label
+           |> Lwt.map CCResult.get_exn
+           |> Lwt.map fst)
+    in
+    (* When one entity specific template exists, expect this to be returned
+       every time *)
+    let expected = [ template; template ] in
+    Alcotest.(check (list Test_utils.message_template) "succeeds" expected res)
+    |> Lwt.return
+  in
+  Lwt.return_unit
+;;
+
+let get_templates_in_multile_languages _ () =
+  let%lwt () =
+    let database_label = Test_utils.Data.database_label in
+    let label = Message_template.Label.ExperimentInvitation in
+    let%lwt experiment = create_experiment () in
+    let languages = Pool_common.Language.[ De; En ] in
+    let%lwt templates =
+      languages
+      |> Lwt_list.map_s (fun lang ->
+           create_invitation
+             lang
+             ~entity_uuid:Experiment.(experiment.id |> Id.to_common)
+             ())
+    in
+    let%lwt res =
+      languages
+      |> Lwt_list.map_s (fun lang ->
+           Message_template.find_by_label_to_send
+             database_label
+             ~entity_uuids:Experiment.[ experiment.id |> Id.to_common ]
+             lang
+             label
+           |> Lwt.map CCResult.get_exn
+           |> Lwt.map fst)
+    in
+    (* Expect all created templates to be returned *)
+    Alcotest.(check (list Test_utils.message_template) "succeeds" templates res)
+    |> Lwt.return
+  in
+  Lwt.return_unit
+;;

--- a/pool/test/test_utils.ml
+++ b/pool/test/test_utils.ml
@@ -11,6 +11,14 @@ let partial_update =
     Custom_field.PartialUpdate.equal
 ;;
 
+let language =
+  Alcotest.testable Pool_common.Language.pp Pool_common.Language.equal
+;;
+
+let message_template =
+  Alcotest.testable Message_template.pp Message_template.equal
+;;
+
 let tenant_smtp_auth =
   Alcotest.testable Pool_tenant.SmtpAuth.pp Pool_tenant.SmtpAuth.equal
 ;;
@@ -393,13 +401,15 @@ module Model = struct
       }
   ;;
 
-  let create_message_template () =
-    let exn = CCResult.get_exn in
+  let create_message_template ?label ?language ?entity_uuid () =
     let open Message_template in
+    let exn = CCResult.get_exn in
+    let label = CCOption.value ~default:Label.AssignmentConfirmation label in
+    let language = CCOption.value ~default:Pool_common.Language.En language in
     { id = Id.create ()
-    ; label = Label.AssignmentConfirmation
-    ; language = Pool_common.Language.En
-    ; entity_uuid = None
+    ; label
+    ; language
+    ; entity_uuid
     ; email_subject = "Subject" |> EmailSubject.create |> exn
     ; email_text = "<div>Hello</div>" |> EmailText.create |> exn
     ; plain_text = "Hello" |> PlainText.create |> exn

--- a/pool/web/handler/admin_session.ml
+++ b/pool/web/handler/admin_session.ml
@@ -151,6 +151,17 @@ let detail req page =
     let* session = Session.find database_label session_id in
     let* experiment = Experiment.find database_label experiment_id in
     let flash_fetcher = CCFun.flip Sihl.Web.Flash.find req in
+    let* { Pool_context.Tenant.tenant; tenant_languages } =
+      Pool_context.Tenant.find req |> Lwt_result.lift
+    in
+    let* _ =
+      Message_template.SessionReminder.prepare
+        database_label
+        tenant
+        tenant_languages
+        experiment
+        session
+    in
     (match page with
      | `Detail ->
        let* assignments =

--- a/pool/web/handler/admin_session.ml
+++ b/pool/web/handler/admin_session.ml
@@ -151,17 +151,6 @@ let detail req page =
     let* session = Session.find database_label session_id in
     let* experiment = Experiment.find database_label experiment_id in
     let flash_fetcher = CCFun.flip Sihl.Web.Flash.find req in
-    let* { Pool_context.Tenant.tenant; tenant_languages } =
-      Pool_context.Tenant.find req |> Lwt_result.lift
-    in
-    let* _ =
-      Message_template.SessionReminder.prepare
-        database_label
-        tenant
-        tenant_languages
-        experiment
-        session
-    in
     (match page with
      | `Detail ->
        let* assignments =

--- a/pool/web/view/page/page_admin_experiments.ml
+++ b/pool/web/view/page/page_admin_experiments.ml
@@ -113,7 +113,7 @@ let notifications
            |> txt
            |> pure
            |> Notification.notification language `Warning
-           |> CCOption.pure)
+           |> CCOption.return)
   |> function
   | [] -> txt ""
   | notifications -> div ~a:[ a_class [ "stack" ] ] notifications

--- a/pool/web/view/page/page_admin_experiments.ml
+++ b/pool/web/view/page/page_admin_experiments.ml
@@ -80,6 +80,45 @@ let experiment_layout ?buttons ?hint language title experiment ?active html =
     ]
 ;;
 
+let notifications
+  language
+  sys_languages
+  invitation_templates
+  session_reminder_templates
+  =
+  let open CCList in
+  let open Pool_common in
+  let open Message_template in
+  Label.
+    [ invitation_templates, ExperimentInvitation
+    ; session_reminder_templates, SessionReminder
+    ]
+  |> filter_map (fun (templates, label) ->
+       if is_empty templates
+       then None
+       else
+         filter
+           (fun lang ->
+             find_opt
+               (fun { language; _ } -> Language.equal language lang)
+               templates
+             |> CCOption.is_none)
+           sys_languages
+         |> function
+         | [] -> None
+         | langs ->
+           I18n.MissingMessageTemplates
+             (Label.to_human label, CCList.map Language.show langs)
+           |> Utils.hint_to_string language
+           |> txt
+           |> pure
+           |> Notification.notification language `Warning
+           |> CCOption.pure)
+  |> function
+  | [] -> txt ""
+  | notifications -> div ~a:[ a_class [ "stack" ] ] notifications
+;;
+
 let message_templates_html
   ?(title =
     fun label ->
@@ -319,6 +358,13 @@ let edit
   flash_fetcher
   =
   let open Message_template in
+  let notifications =
+    notifications
+      language
+      sys_languages
+      invitation_templates
+      session_reminder_templates
+  in
   let form =
     experiment_form ~experiment context default_reminder_lead_time flash_fetcher
   in
@@ -333,7 +379,8 @@ let edit
   let html =
     div
       ~a:[ a_class [ "stack-lg" ] ]
-      [ form
+      [ notifications
+      ; form
       ; message_templates_html Label.ExperimentInvitation invitation_templates
       ; message_templates_html Label.SessionReminder session_reminder_templates
       ]
@@ -355,37 +402,11 @@ let detail
   =
   let experiment_path = build_experiment_path experiment in
   let notifications =
-    let open CCList in
-    let open Pool_common in
-    let open Message_template in
-    Label.
-      [ invitation_templates, ExperimentInvitation
-      ; session_reminder_templates, SessionReminder
-      ]
-    |> filter_map (fun (templates, label) ->
-         if is_empty templates
-         then None
-         else
-           filter
-             (fun lang ->
-               find_opt
-                 (fun { language; _ } -> Language.equal language lang)
-                 templates
-               |> CCOption.is_none)
-             sys_languages
-           |> function
-           | [] -> None
-           | langs ->
-             I18n.MissingMessageTemplates
-               (Label.to_human label, CCList.map Language.show langs)
-             |> Utils.hint_to_string language
-             |> txt
-             |> pure
-             |> Notification.notification language `Warning
-             |> CCOption.pure)
-    |> function
-    | [] -> txt ""
-    | notifications -> div ~a:[ a_class [ "stack" ] ] notifications
+    notifications
+      language
+      sys_languages
+      invitation_templates
+      session_reminder_templates
   in
   let delete_form =
     match session_count > 0 with


### PR DESCRIPTION
Define fallback logic, if specific template is not available in all languages

* [x] If one template (language) is missing, do not fallback to global templates, use an experiment specific template
* [x] Show alert, that templates are missing (check all sessions / experiment languages), to find out, if something is missing