### PR TITLE
Bug/857 bugreport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - reply-to address to emails, using tenant contact email address (system settings)
+- buttons to reset forms
 
 ### Changed
 
 - when signing up for a session with follow-ups, the contact receives one confirmation message containing all sessions
+### Fixed
+
+- filter by boolean fields
+- custom fields with the option 'admin_view_only' will automatically have 'admin_input_only' set to true
+- partial update of 'admin_view_only' fields
 
 ## [0.1.3](https://github.com/uzh/pool/tree/0.1.3) - 2023-03-01
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^36.0.0",
-    "@econ/frontend-framework": "^1.0.10",
+    "@econ/frontend-framework": "^1.0.11",
     "flatpickr": "^4.6.13",
     "htmx.org": "^1.6.0"
   }

--- a/pool/app/custom_field/entity.ml
+++ b/pool/app/custom_field/entity.ml
@@ -546,7 +546,7 @@ let create
   =
   let open CCResult in
   let required = if admin_input_only then false else required in
-  let admin_input_only = if admin_view_only then true else admin_input_only in
+  let admin_input_only = admin_view_only || admin_input_only in
   match (field_type : FieldType.t) with
   | FieldType.Boolean ->
     Ok

--- a/pool/app/custom_field/entity.ml
+++ b/pool/app/custom_field/entity.ml
@@ -546,6 +546,7 @@ let create
   =
   let open CCResult in
   let required = if admin_input_only then false else required in
+  let admin_input_only = if admin_view_only then true else admin_input_only in
   match (field_type : FieldType.t) with
   | FieldType.Boolean ->
     Ok

--- a/pool/app/filter/repo/repo_utils.ml
+++ b/pool/app/filter/repo/repo_utils.ml
@@ -43,7 +43,7 @@ let add_value_to_params operator value dyn =
   in
   let add c v = Dynparam.add c v dyn in
   match value with
-  | Bool b -> add Caqti_type.bool b
+  | Bool b -> add Caqti_type.string (Utils.Bool.to_string b)
   | Date d -> add Caqti_type.ptime d
   | Language lang -> add Caqti_type.string (Pool_common.Language.show lang)
   | Nr n -> add Caqti_type.float n

--- a/pool/app/pool_common/entity_message.ml
+++ b/pool/app/pool_common/entity_message.ml
@@ -426,6 +426,7 @@ type control =
   | Resend of Field.t option
   | ResetPlainText
   | Reset
+  | ResetForm
   | Save of Field.t option
   | SelectAll of Field.t option
   | SelectFilePlaceholder

--- a/pool/app/pool_common/locales/locales_de.ml
+++ b/pool/app/pool_common/locales/locales_de.ml
@@ -484,6 +484,7 @@ let control_to_string = function
       (field_to_string Field.EmailText)
   | Resend field -> format_submit "erneut senden" field
   | Reset -> "zurücksetzen"
+  | ResetForm -> "Formular zurücksetzen"
   | Save field -> format_submit "speichern" field
   | SelectAll field -> format_submit "alle auswählen" field
   | SelectFilePlaceholder -> format_submit "datei auswählen.." None

--- a/pool/app/pool_common/locales/locales_en.ml
+++ b/pool/app/pool_common/locales/locales_en.ml
@@ -446,6 +446,7 @@ let control_to_string = function
   | Reschedule field -> format_submit "reschedule" field
   | Resend field -> format_submit "resend" field
   | Reset -> "reset"
+  | ResetForm -> "reset form"
   | ResetPlainText ->
     Format.asprintf
       "Reset %s to rich '%s'"

--- a/pool/web/handler/helpers_partial_update.ml
+++ b/pool/web/handler/helpers_partial_update.ml
@@ -1,7 +1,8 @@
 module PoolField = Pool_common.Message.Field
 module HttpUtils = Http_utils
 
-let parse_urlencoded req database_label language urlencoded contact_id =
+let parse_urlencoded ~is_admin req database_label language urlencoded contact_id
+  =
   let open Pool_common.Message in
   let open Utils.Lwt_result.Infix in
   let find_param_list name =
@@ -31,7 +32,7 @@ let parse_urlencoded req database_label language urlencoded contact_id =
       field_id
       |> CCOption.to_result InvalidHtmxRequest
       |> Lwt_result.lift
-      >>= Custom_field.find_by_contact database_label contact_id
+      >>= Custom_field.find_by_contact ~is_admin database_label contact_id
       >|+ fun f -> Custom_field.Public.to_common_field language f
   in
   let* version =
@@ -96,6 +97,7 @@ let update ?contact req =
     in
     let* field, version, value, field_id =
       parse_urlencoded
+        ~is_admin
         req
         database_label
         language
@@ -193,7 +195,7 @@ let update ?contact req =
                field_id
                |> CCOption.to_result InvalidHtmxRequest
                |> Lwt_result.lift
-               >>= find_by_contact database_label (Contact.id contact)
+               >>= find_by_contact ~is_admin database_label (Contact.id contact)
              in
              (match field with
               | Error error ->

--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -662,3 +662,14 @@ let multi_select
            (div ~a:[ a_class [ "flex-basis-100" ] ])
     ]
 ;;
+
+let reset_form_button language =
+  span
+    ~a:
+      [ a_class [ "has-icon"; "color-red"; "pointer" ]
+      ; a_user_data "reset-form" ""
+      ]
+    [ Component_icon.icon `RefreshOutline
+    ; txt Pool_common.(Utils.control_to_string language Message.Reset)
+    ]
+;;

--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -251,6 +251,7 @@ let timespan_picker
 let checkbox_element
   ?(additional_attributes = [])
   ?(as_switch = false)
+  ?(switcher_class = [])
   ?(classnames = [])
   ?error
   ?flash_fetcher
@@ -295,7 +296,7 @@ let checkbox_element
       then
         div
           [ label
-              ~a:[ a_class [ "switch" ] ]
+              ~a:[ a_class ("switch" :: switcher_class) ]
               [ base; span ~a:[ a_class [ "slider" ] ] [] ]
           ]
       else base

--- a/pool/web/view/htmx/htmx.ml
+++ b/pool/web/view/htmx/htmx.ml
@@ -148,6 +148,7 @@ let create
   | Boolean boolean ->
     Input.checkbox_element
       ~as_switch:true
+      ~switcher_class:input_class
       ~additional_attributes:(additional_attributes ())
       ?append_html
       ~classnames

--- a/pool/web/view/page/page_admin_custom_fields.ml
+++ b/pool/web/view/page/page_admin_custom_fields.ml
@@ -476,13 +476,17 @@ let field_form
       ]
     |> CCList.map (fun (hint, field_type) ->
          let hidden =
-           field_type_opt
-           |> CCOption.map_or
-                ~default:true
-                CCFun.(FieldType.(equal Text) %> not)
-           |> function
-           | true -> [ "hidden" ]
-           | false -> []
+           let published =
+             custom_field
+             |> CCOption.map_or
+                  ~default:false
+                  (Custom_field.published_at %> CCOption.is_some)
+           in
+           let equal_type =
+             field_type_opt
+             |> CCOption.map_or ~default:false FieldType.(equal field_type)
+           in
+           if published || not equal_type then [ "hidden" ] else []
          in
          div
            ~a:

--- a/pool/web/view/page/page_admin_custom_fields.ml
+++ b/pool/web/view/page/page_admin_custom_fields.ml
@@ -608,16 +608,19 @@ let field_form
           ; checkbox_element Message.Field.Disabled (disabled %> Disabled.value)
           ; div
               ~a:[ a_class [ "flexrow" ] ]
-              [ submit_element
-                  ~classnames:[ "push" ]
-                  language
-                  Message.(
-                    let field = Some Field.CustomField in
-                    match custom_field with
-                    | None -> Create field
-                    | Some _ -> Update field)
-                  ~submit_type:`Primary
-                  ()
+              [ div
+                  ~a:[ a_class [ "push"; "flexrow"; "flex-gap-lg" ] ]
+                  [ reset_form_button language
+                  ; submit_element
+                      language
+                      Message.(
+                        let field = Some Field.CustomField in
+                        match custom_field with
+                        | None -> Create field
+                        | Some _ -> Update field)
+                      ~submit_type:`Primary
+                      ()
+                  ]
               ]
           ]
       ; (Format.asprintf

--- a/pool/web/view/page/page_admin_experiments.ml
+++ b/pool/web/view/page/page_admin_experiments.ml
@@ -317,16 +317,19 @@ let experiment_form
         ]
     ; div
         ~a:[ a_class [ "flexrow" ] ]
-        [ submit_element
-            ~classnames:[ "push" ]
-            language
-            Message.(
-              let field = Some Field.Experiment in
-              match experiment with
-              | None -> Create field
-              | Some _ -> Update field)
-            ~submit_type:`Primary
-            ()
+        [ div
+            ~a:[ a_class [ "push"; "flexrow"; "flex-gap-lg" ] ]
+            [ reset_form_button language
+            ; submit_element
+                language
+                Message.(
+                  let field = Some Field.Experiment in
+                  match experiment with
+                  | None -> Create field
+                  | Some _ -> Update field)
+                ~submit_type:`Primary
+                ()
+            ]
         ]
     ]
 ;;

--- a/resources/index.scss
+++ b/resources/index.scss
@@ -130,3 +130,7 @@ abbr[title] {
 .nobr {
     white-space: nowrap;
 }
+
+input.success {
+    animation-duration: 2s;
+}

--- a/resources/index.scss
+++ b/resources/index.scss
@@ -130,7 +130,3 @@ abbr[title] {
 .nobr {
     white-space: nowrap;
 }
-
-input.success {
-    animation-duration: 2s;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
     "@ckeditor/ckeditor5-utils" "^36.0.1"
     lodash-es "^4.17.15"
 
-"@econ/frontend-framework@^1.0.10":
-  version "1.0.10"
-  resolved "https://gitlab.uzh.ch/api/v4/projects/662/packages/npm/@econ/frontend-framework/-/@econ/frontend-framework-1.0.10.tgz#6de5914856cc5ca9e0e4c3f3f28b972531dfaea2"
-  integrity sha1-beWRSFbMXKng5MPz8ouXJTHfrqI=
+"@econ/frontend-framework@^1.0.11":
+  version "1.0.11"
+  resolved "https://gitlab.uzh.ch/api/v4/projects/662/packages/npm/@econ/frontend-framework/-/@econ/frontend-framework-1.0.11.tgz#1312410b275c8217064f8cd6c0d980a064c14194"
+  integrity sha1-ExJBCydcghcGT4zWwNmAoGTBQZQ=
   dependencies:
     fantasticon "^1.2.3"
     minify "^8.0.0"


### PR DESCRIPTION
- Hide "Field type hints" when editing custom field (only show when creating)
- Custom field > `admin_view_only`: Set `admin_input_only` to true
- Fix Partial updates of `admin_view_only` fields 
- Fix filter by booleans 

