### PR TITLE
Feature/1933 contact session

### DIFF
--- a/pool/app/message_template/message_template.ml
+++ b/pool/app/message_template/message_template.ml
@@ -155,6 +155,7 @@ let session_params
   in
   [ "sessionId", session_id
   ; "sessionStart", start
+  ; "sessionDateTime", Session.start_end_to_human session
   ; "sessionDuration", duration
   ; "sessionOverview", session_overview
   ]

--- a/pool/app/pool_common/locales/locales_de.ml
+++ b/pool/app/pool_common/locales/locales_de.ml
@@ -122,7 +122,7 @@ let rec field_to_string =
   | Limit -> "Limit"
   | Limitations -> "Einschränkungen"
   | Link -> "Link"
-  | Location -> "Lokalität"
+  | Location -> "Standort"
   | LoginCount -> "Logins von Kontakten"
   | LogoType -> "Logo Typ"
   | Mailing -> "Versand"

--- a/pool/app/session/entity.ml
+++ b/pool/app/session/entity.ml
@@ -252,6 +252,10 @@ let session_date_to_human (session : t) =
   session.start |> Start.value |> Pool_common.Utils.Time.formatted_date_time
 ;;
 
+let start_end_to_human ({ start; duration; _ } : t) =
+  Utils.Ptime.format_datetime_with_span start duration
+;;
+
 let compare_start s1 s2 = Start.compare s1.start s2.start
 
 let add_follow_ups_to_parents groups (parent, session) =
@@ -373,6 +377,10 @@ module Public = struct
   let get_session_end (session : t) =
     Ptime.add_span session.start session.duration
     |> CCOption.get_exn_or "Session end not in range"
+  ;;
+
+  let start_end_to_human ({ start; duration; _ } : t) =
+    Utils.Ptime.format_datetime_with_span start duration
   ;;
 end
 

--- a/pool/app/session/repo/repo.ml
+++ b/pool/app/session/repo/repo.ml
@@ -158,7 +158,7 @@ module Sql = struct
           pool_sessions.max_participants,
           pool_sessions.min_participants,
           pool_sessions.overbook,
-          (SELECT COUNT(pool_assignments.id) FROM pool_assignments WHERE session_uuid = pool_sessions.uuid AND marked_as_deleted = 0),
+          (SELECT COUNT(pool_assignments.id) FROM pool_assignments WHERE session_uuid = pool_sessions.uuid AND marked_as_deleted = 0 AND pool_assignments.canceled_at IS NULL),
           pool_sessions.canceled_at
         FROM pool_sessions
         INNER JOIN pool_locations

--- a/pool/app/session/session.mli
+++ b/pool/app/session/session.mli
@@ -154,6 +154,7 @@ val is_fully_booked : t -> bool
 val available_spots : t -> int
 val has_assignments : t -> bool
 val session_date_to_human : t -> string
+val start_end_to_human : t -> string
 
 type event =
   | Created of (t * Experiment.Id.t)
@@ -192,6 +193,7 @@ module Public : sig
   val assignment_creatable : t -> (unit, Pool_common.Message.error) result
   val group_and_sort : t list -> (t * t list) list
   val get_session_end : t -> Ptime.t
+  val start_end_to_human : t -> string
 end
 
 val to_public : t -> Public.t

--- a/pool/app/utils/utils_ptime.ml
+++ b/pool/app/utils/utils_ptime.ml
@@ -36,6 +36,10 @@ let to_local_date date =
   |> CCOption.get_exn_or "Invalid ptime provided"
 ;;
 
+let equal_date ((y1, m1, d1) : Ptime.date) ((y2, m2, d2) : Ptime.date) =
+  CCInt.(equal y1 y2 && equal m1 m2 && equal d1 d2)
+;;
+
 let formatted_date ptime =
   ptime |> to_local_date |> Ptime.to_date |> date_to_human
 ;;
@@ -58,6 +62,22 @@ let timespan_to_minutes timespan =
   |> Ptime.Span.to_int_s
   |> CCOption.map_or ~default:"" (fun timespan ->
     timespan / 60 |> CCInt.to_string)
+;;
+
+let format_datetime_with_span start duration =
+  let end_time =
+    Ptime.add_span start duration |> CCOption.get_exn_or "end time not in range"
+  in
+  let format_end_date =
+    if equal_date (Ptime.to_date start) (Ptime.to_date end_time)
+    then formatted_time ~with_seconds:false
+    else formatted_date_time
+  in
+  Format.asprintf
+    "%s - %s (%s)"
+    (formatted_date_time start)
+    (format_end_date end_time)
+    (formatted_timespan duration)
 ;;
 
 (* Utilities *)

--- a/pool/web/handler/contact_experiment.ml
+++ b/pool/web/handler/contact_experiment.ml
@@ -40,6 +40,7 @@ let index req =
 ;;
 
 let show req =
+  let open CCFun in
   let open Utils.Lwt_result.Infix in
   let error_path = "/experiments" in
   let result ({ Pool_context.database_label; _ } as context) =
@@ -56,6 +57,7 @@ let show req =
     let* grouped_sessions =
       Session.find_all_public_for_experiment database_label contact id
       >|+ Session.Public.group_and_sort
+      >|+ CCList.filter (fst %> Session.Public.is_fully_booked %> not)
     in
     let find_sessions fnc =
       let open Assignment in

--- a/pool/web/view/component/component_location.ml
+++ b/pool/web/view/component/component_location.ml
@@ -27,24 +27,21 @@ let formatted_address language address =
        []
 ;;
 
-let preview language (location : Pool_location.t) =
+let preview (location : Pool_location.t) =
   let open Pool_location in
-  let name = p [ txt (Name.value location.name) ] in
-  let link =
-    let open Address in
-    match location.address with
-    | Virtual -> txt ""
-    | Physical _ ->
-      let url =
-        Format.asprintf
-          "%s/%s"
-          Pool_common.Message.Field.(human_url Location)
-          (Id.value location.id)
-        |> Sihl.Web.externalize_path
-      in
-      a
-        ~a:[ a_href url ]
-        [ txt Pool_common.(Utils.text_to_string language I18n.LocationDetails) ]
-  in
-  [ name; br (); link ] |> address
+  let name = txt (Name.value location.name) in
+  let open Address in
+  (match location.address with
+   | Virtual -> p [ name ]
+   | Physical _ ->
+     let url =
+       Format.asprintf
+         "%s/%s"
+         Pool_common.Message.Field.(human_url Location)
+         (Id.value location.id)
+       |> Sihl.Web.externalize_path
+     in
+     a ~a:[ a_href url ] [ name ])
+  |> CCList.return
+  |> address
 ;;

--- a/pool/web/view/page/page_admin_assignments.ml
+++ b/pool/web/view/page/page_admin_assignments.ml
@@ -414,7 +414,6 @@ let edit
   in
   let session_data =
     let open Session in
-    let field_to_string = Pool_common.Utils.field_to_string language in
     div
       ~a:[ a_class [ "stack"; "inset"; "border"; " bg-grey-light" ] ]
       [ h3
@@ -423,15 +422,8 @@ let edit
                 Utils.field_to_string language Message.Field.Session
                 |> CCString.capitalize_ascii)
           ]
-      ; p
-          [ txt (field_to_string Field.Start |> CCString.capitalize_ascii)
-          ; txt ": "
-          ; session.start
-            |> Start.value
-            |> Pool_common.Utils.Time.formatted_date_time
-            |> txt
-          ]
-      ; Component.Location.preview language session.location
+      ; p [ session |> Session.start_end_to_human |> txt ]
+      ; Component.Location.preview session.location
       ]
   in
   [ div

--- a/pool/web/view/page/page_admin_session.ml
+++ b/pool/web/view/page/page_admin_session.ml
@@ -741,7 +741,13 @@ let detail
       let counters =
         let length lst = lst |> CCList.length |> CCInt.to_string |> txt in
         let open Assignment in
-        let assignment_count = Field.AssignmentCount, assignments |> length in
+        let assignment_count =
+          ( Field.AssignmentCount
+          , session.assignment_count
+            |> AssignmentCount.value
+            |> CCInt.to_string
+            |> txt )
+        in
         match session.Session.closed_at with
         | None -> [ assignment_count ]
         | Some (_ : Ptime.t) ->

--- a/pool/web/view/page/page_contact_experiment.ml
+++ b/pool/web/view/page/page_contact_experiment.ml
@@ -3,6 +3,7 @@ open Component.Input
 module PageSession = Page_contact_sessions
 module Assignment = Page_contact_assignment
 module HttpUtils = Http_utils
+module Field = Pool_common.Message.Field
 
 let index
   experiment_list
@@ -197,20 +198,22 @@ let show
     | false -> Message.AddToWaitingList, "primary"
   in
   let session_list sessions =
-    if CCList.is_empty sessions
-    then
-      p
-        [ Utils.text_to_string language (I18n.EmtpyList Message.Field.Sessions)
-          |> txt
-        ]
-    else
-      div
-        [ h2
-            ~a:[ a_class [ "heading-2" ] ]
-            [ txt (Utils.nav_link_to_string language I18n.Sessions) ]
-        ; p [ txt (hint_to_string I18n.ExperimentSessionsPublic) ]
-        ; div [ PageSession.public_overview sessions experiment language ]
-        ]
+    div
+      ([ h2
+           ~a:[ a_class [ "heading-2" ] ]
+           [ txt (Utils.nav_link_to_string language I18n.Sessions) ]
+       ; p [ txt (hint_to_string I18n.ExperimentSessionsPublic) ]
+       ]
+       @
+       if CCList.is_empty sessions
+       then
+         [ p
+             [ Utils.text_to_string language (I18n.EmtpyList Field.Sessions)
+               |> txt
+             ]
+         ]
+       else [ div [ PageSession.public_overview sessions experiment language ] ]
+      )
   in
   let waiting_list_form () =
     let form_action =

--- a/pool/web/view/page/page_contact_sessions.ml
+++ b/pool/web/view/page/page_contact_sessions.ml
@@ -49,11 +49,8 @@ let session_item layout language (experiment : Experiment.Public.t) session =
           ; br ()
           ]
         else [])
-       @ [ txt (session.Public.start |> Start.value |> Time.formatted_date_time)
-         ])
-  ; txt (session.Public.duration |> Duration.value |> Time.formatted_timespan)
-  ; txt (session |> Public.get_session_end |> Time.formatted_time)
-  ; session.Public.location |> Component.Location.preview language
+       @ [ txt (Session.Public.start_end_to_human session) ])
+  ; session.Public.location |> Component.Location.preview
   ]
   |> fun cells ->
   match layout with
@@ -62,9 +59,7 @@ let session_item layout language (experiment : Experiment.Public.t) session =
 ;;
 
 let public_overview sessions experiment language =
-  let thead =
-    Field.[ Some Start; Some Duration; Some End; Some Location; None ]
-  in
+  let thead = Field.[ Some DateTime; Some Location; None ] in
   let session_item = session_item `Register language experiment in
   CCList.flat_map
     (fun (session, follow_ups) ->


### PR DESCRIPTION
- hide fully booked sessions for contact registration
- always show hint about empty session list for contact registration
- fix session registration sessions with cancelled assignments
- reformat displayed session start/end/duration
- add message template element for it