### PR TITLE
update order of delete requests

### DIFF
--- a/pool/app/contact/repo/repo_sql.ml
+++ b/pool/app/contact/repo/repo_sql.ml
@@ -367,9 +367,9 @@ let delete_unverified pool id =
       request
       (Pool_common.Id.value id)
   in
-  let%lwt _ = exec delete_unverified_user_request in
-  let%lwt _ = exec delete_unverified_email_verifications_request in
-  exec delete_unverified_contact_request
+  let%lwt () = exec delete_unverified_contact_request in
+  let%lwt () = exec delete_unverified_email_verifications_request in
+  exec delete_unverified_user_request
 ;;
 
 let find_to_trigger_profile_update_request =


### PR DESCRIPTION
Ensure the fk_constraint is not violated when deleting contact and user after re-signup with an existing unverified address.