### PR TITLE
Delete SMTP Server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
 // devcontainer docu https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference
 {
   "name": "Pool Tool",
-  "dockerComposeFile": ["./docker-compose.yml", "./docker-compose.override.yml"],
+  "dockerComposeFile": [
+    "./docker-compose.yml",
+    "./docker-compose.override.yml"
+  ],
   "service": "dev",
   "runServices": [
     "dev",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           SMTP_SENDER: test@econ.uzh.ch
           TEST_EMAIL: test@econ.uzh.ch
         with:
-          image: ocaml/opam:debian-10-ocaml-4.14
+          image: ocaml/opam:debian-12-ocaml-4.14
           options: -v ${{ github.workspace }}:/app -w /app -e DATABASE_URL -e DATABASE_URL_TENANT_ONE -e TEST_EMAIL -e SMTP_SENDER -e SIHL_ENV -e EMAIL_RATE_LIMIT -e MATCHER_MAX_CAPACITY
           run: |
             # Reclaim required directory permissions

--- a/pool/app/email/email.mli
+++ b/pool/app/email/email.mli
@@ -151,6 +151,8 @@ module SmtpAuth : sig
     ; default : Default.t
     }
 
+  type smtp = t
+
   type update_password =
     { id : Id.t
     ; password : Password.t option
@@ -171,6 +173,8 @@ module SmtpAuth : sig
       ; protocol : Protocol.t
       ; default : Default.t
       }
+
+    val to_entity : t -> smtp
 
     val create
       :  ?id:Id.t
@@ -290,6 +294,7 @@ type event =
   | BulkSent of (Sihl_email.t * SmtpAuth.Id.t option) list
   | SmtpCreated of SmtpAuth.Write.t
   | SmtpEdited of SmtpAuth.t
+  | SmtpDeleted of SmtpAuth.Id.t
   | SmtpPasswordEdited of SmtpAuth.update_password
 
 val handle_event : Pool_database.Label.t -> event -> unit Lwt.t

--- a/pool/app/email/entity_smtp.ml
+++ b/pool/app/email/entity_smtp.ml
@@ -93,6 +93,8 @@ type t =
   }
 [@@deriving eq, show, sexp_of]
 
+type smtp = t
+
 type update_password =
   { id : Id.t
   ; password : Password.t option [@opaque]
@@ -125,5 +127,17 @@ module Write = struct
       ; protocol
       ; default
       }
+  ;;
+
+  let to_entity (t : t) : smtp =
+    { id = t.id
+    ; label = t.label
+    ; server = t.server
+    ; port = t.port
+    ; username = t.username
+    ; mechanism = t.mechanism
+    ; protocol = t.protocol
+    ; default = t.default
+    }
   ;;
 end

--- a/pool/app/email/event.ml
+++ b/pool/app/email/event.ml
@@ -61,6 +61,7 @@ type event =
   | BulkSent of (Sihl_email.t * SmtpAuth.Id.t option) list
   | SmtpCreated of SmtpAuth.Write.t
   | SmtpEdited of SmtpAuth.t
+  | SmtpDeleted of SmtpAuth.Id.t
   | SmtpPasswordEdited of SmtpAuth.update_password
 [@@deriving eq, show, variants]
 
@@ -83,5 +84,8 @@ let handle_event pool : event -> unit Lwt.t = function
     Lwt.return_unit
   | SmtpPasswordEdited updated_password ->
     let%lwt () = Repo.Smtp.update_password pool updated_password in
+    Lwt.return_unit
+  | SmtpDeleted id ->
+    let%lwt () = Repo.Smtp.delete pool id in
     Lwt.return_unit
 ;;

--- a/pool/app/email/repo/repo.ml
+++ b/pool/app/email/repo/repo.ml
@@ -25,6 +25,7 @@ module Smtp = struct
   let find_all = Sql.Smtp.find_all
   let insert = Sql.Smtp.insert
   let update = Sql.Smtp.update
+  let delete = Sql.Smtp.delete
 
   let update_password label Entity.SmtpAuth.{ id; password } =
     Sql.Smtp.update_password label (id, password)

--- a/pool/app/email/repo/repo_sql.ml
+++ b/pool/app/email/repo/repo_sql.ml
@@ -381,6 +381,19 @@ module Smtp = struct
     Utils.Database.exec (Database.Label.value pool) update_request t
   ;;
 
+  let delete_request =
+    let open Caqti_request.Infix in
+    {sql|
+        DELETE FROM pool_smtp
+        WHERE uuid = UNHEX(REPLACE(?, '-', ''))
+    |sql}
+    |> RepoEntity.SmtpAuth.(Id.t ->. Caqti_type.unit)
+  ;;
+
+  let delete pool t =
+    Utils.Database.exec (Database.Label.value pool) delete_request t
+  ;;
+
   let update_password_request =
     let open Caqti_request.Infix in
     {sql|

--- a/pool/app/pool_common/entity_i18n.ml
+++ b/pool/app/pool_common/entity_i18n.ml
@@ -254,6 +254,7 @@ type confirmable =
   | DeleteCustomField
   | DeleteCustomFieldOption
   | DeleteEmailSuffix
+  | DeleteSmtpServer
   | DeleteExperiment
   | DeleteExperimentFilter
   | DeleteFile

--- a/pool/app/pool_common/locales/i18n_de.ml
+++ b/pool/app/pool_common/locales/i18n_de.ml
@@ -574,6 +574,7 @@ let confirmable_to_string confirmable =
    | DeleteMailing -> "den Versand", "löschen", None
    | DeleteMessageTemplate -> "das Nachrichtentemplate", "löschen", None
    | DeleteSession -> "die Session", "löschen", None
+   | DeleteSmtpServer -> "E-Mail Server", "löschen", None
    | MarkAssignmentAsDeleted -> "die Anmeldung", "als gelöscht markieren", None
    | MarkAssignmentWithFollowUpsAsDeleted ->
      ( "die Anmeldung"

--- a/pool/app/pool_common/locales/i18n_en.ml
+++ b/pool/app/pool_common/locales/i18n_en.ml
@@ -552,6 +552,7 @@ let confirmable_to_string confirmable =
    | DeleteMailing -> "mailing", "delete", None
    | DeleteMessageTemplate -> "message template", "delete", None
    | DeleteSession -> "session", "delete", None
+   | DeleteSmtpServer -> "email Server", "delete", None
    | PublisCustomField ->
      ( "field an all associated options"
      , "publish"

--- a/pool/routes/routes.ml
+++ b/pool/routes/routes.ml
@@ -709,6 +709,7 @@ module Admin = struct
         let specific =
           [ get "" ~middlewares:[ Access.update ] show
           ; post "" ~middlewares:[ Access.update ] update
+          ; post "/delete" ~middlewares:[ Access.delete ] delete
           ; post "/password" ~middlewares:[ Access.update ] update_password
           ]
         in
@@ -844,6 +845,7 @@ module Root = struct
         [ get "" ~middlewares:[ Access.index ] show_smtp
         ; post "/create" ~middlewares:[ Access.create ] create_smtp
         ; post "/:smtp" ~middlewares:[ Access.update ] update_smtp
+        ; post "/:smtp/delete" ~middlewares:[ Access.delete ] delete_smtp
         ; post
             "/:smtp/password"
             ~middlewares:[ Access.update ]

--- a/pool/test/command.ml
+++ b/pool/test/command.ml
@@ -87,6 +87,14 @@ let () =
             "create tenant smtp auth and force default"
             `Quick
             Tenant_test.create_smtp_force_defaut
+        ; test_case
+            "update tenant smtp auth"
+            `Quick
+            Tenant_test.update_smtp_auth
+        ; test_case
+            "delete tenant smtp auth"
+            `Quick
+            Tenant_test.delete_smtp_auth
         ; test_case "create tenant" `Quick Tenant_test.create_tenant
         ; test_case
             "update tenant details"

--- a/pool/test/integration.ml
+++ b/pool/test/integration.ml
@@ -30,6 +30,8 @@ let suite =
               `Slow
               update_terms_and_conditions
           ; test_case "login after terms update" `Slow login_after_terms_update
+          ; test_case "can create smtp auth" `Slow create_smtp_auth
+          ; test_case "can delete smtp auth" `Slow delete_smtp_auth
           ] )
     ; ( "dev/test"
       , [ test_case "intercept email" `Slow Common_test.validate_email ] )

--- a/pool/test/test_utils.ml
+++ b/pool/test/test_utils.ml
@@ -30,6 +30,7 @@ let error =
 ;;
 
 let contact = Alcotest.testable Contact.pp Contact.equal
+let smtp_auth = Alcotest.testable Email.SmtpAuth.pp Email.SmtpAuth.equal
 
 let check_result ?(msg = "succeeds") =
   let open Alcotest in
@@ -546,3 +547,11 @@ module Repo = struct
     Pool_location.find_all Data.database_label ||> CCList.hd
   ;;
 end
+
+(* NOTE(@leostera): here be dragons. This machinery gets rid of any resulting
+   value we have. It will fail a test if the underlying promise returns an
+   Error. *)
+let case fn (_switch : Lwt_switch.t) () : unit Lwt.t =
+  let result = Lwt_result.get_exn @@ Lwt_result.catch fn in
+  Lwt.map (fun _ -> ()) result
+;;

--- a/pool/web/handler/root_settings.ml
+++ b/pool/web/handler/root_settings.ml
@@ -17,4 +17,6 @@ let update_smtp_password =
     Pool_common.Message.SmtpPasswordUpdated
 ;;
 
+let delete_smtp = Admin_settings_smtp.delete_base `Root
+
 module Access = Admin_settings.Smtp.Access

--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -10,6 +10,20 @@ let submit_type_to_class = function
   | `Success -> "success"
 ;;
 
+let button_group buttons =
+  div
+    ~a:
+      [ a_class
+          [ "flexrow"
+          ; "justify-end"
+          ; "align-center"
+          ; "items-center"
+          ; "flex-gap-xs"
+          ]
+      ]
+    buttons
+;;
+
 let language_select
   options
   selected

--- a/pool/web/view/page/page_admin_settings_smtp.ml
+++ b/pool/web/view/page/page_admin_settings_smtp.ml
@@ -30,6 +30,22 @@ let index Pool_context.{ language; _ } location smtp_auth_list =
      |> Component.Table.fields_to_txt language)
     @ [ add_btn ]
   in
+  let delete_button (auth : SmtpAuth.t) =
+    let open SmtpAuth in
+    let action_path =
+      Format.asprintf "%s/%s/delete" (base_path location) (auth.id |> Id.value)
+    in
+    form
+      ~a:
+        [ a_method `Post
+        ; a_action action_path
+        ; a_user_data
+            "confirmable"
+            Pool_common.(
+              Utils.confirmable_to_string language I18n.DeleteSmtpServer)
+        ]
+      [ submit_icon ~classnames:[ "error" ] Icon.TrashOutline ]
+  in
   let rows =
     let open SmtpAuth in
     smtp_auth_list
@@ -40,8 +56,14 @@ let index Pool_context.{ language; _ } location smtp_auth_list =
       ; auth.mechanism |> Mechanism.show |> txt
       ; auth.protocol |> Protocol.show |> txt
       ; auth.default |> Default.value |> Utils.Bool.to_string |> txt
-      ; edit_link
-          (Format.asprintf "%s/%s" (base_path location) (auth.id |> Id.value))
+      ; button_group
+          [ edit_link
+              (Format.asprintf
+                 "%s/%s"
+                 (base_path location)
+                 (auth.id |> Id.value))
+          ; delete_button auth
+          ]
       ])
   in
   div


### PR DESCRIPTION
Hello folks! 👋🏼 Here's a PR sketching support for deleting SMTP servers.

It includes:

- [x] Add `SmtpDeleted` Event
- [x] Add repo support for deleting rows from `pool_smtp` table by id
- [x] Add `Smtp.Delete` command
- [x] Add `Smtp.Access` guard
- [x] Add `Smtp.delete` controller
- [x] Add `/admin/settings/smtp/:id/delete` route
- [x] Add button group and delete button on Smtp index page
- [x] Add I18n key and translations for the delete confirmation message

Missing a few tests, and probably isn't entirely fitting the repo-style yet. I have some comments but we can discuss them over a call first.

Happy to address/amend anything, just let me know 🙌🏼 