### PR TITLE
dx: use ocaml/setup-ocaml for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,88 @@ jobs:
         with:
           webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
 
+  fast-build:
+    name: Build and test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - "4.14.1"
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      EMAIL_RATE_LIMIT: 3600
+      MATCHER_MAX_CAPACITY: 80
+      MYSQL_DATABASE: test_econ
+      MYSQL_ROOT_PASSWORD: password
+
+    services:
+      database-root:
+        image: mariadb:10.6
+        env:
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        ports:
+          - 3306:3306
+
+      database-tenant:
+        image: mariadb:10.6
+        env:
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        ports:
+          - 3307:3306
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: add commit SHA for non-production builds
+        if: github.ref_type != 'tag'
+        run: |
+          CURRENT_VERSION=$(grep -oP 'let to_string = "\K[^"]+' ./pool/version/version.ml)
+          GIT_SHA=$(git rev-parse --short HEAD)
+          sed -i "s/^let to_string = \".*\"/let to_string = \"${CURRENT_VERSION}-${GIT_SHA}\"/" ./pool/version/version.ml
+
+      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
+          opam-pin: false
+          opam-depext: false
+
+      - name: "Setup Pins and Deps"
+        run: |
+          ./scripts/setup.sh
+          opam install . --deps-only --with-test
+
+      - name: "Build"
+        run: opam exec -- dune build
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pool.exe
+          path: _build/default/pool/run/run.exe
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: tests
+          path: _build/default/pool/test/
+
+            #      - name: Notify about failure
+            #        if: failure()
+            #        uses: ./.github/actions/notify-failure
+            #        with:
+            #          webhook: ${{ secrets.ECON_TEAMS_WEBHOOK }}
+
   assets:
     name: Build assets
     if: github.repository == 'uzh/pool'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,20 @@ jobs:
       - name: "Build"
         run: opam exec -- dune build
 
+      - name: "Test"
+        run: |
+          opam config exec -- dune exec --root . pool/run/run.exe migrate.root
+          opam config exec -- dune exec --root . pool/run/run.exe seed.root.clean
+          opam config exec -- dune exec --root . pool/run/run.exe migrate.tenant
+          opam config exec -- dune exec --root . pool/run/run.exe seed.tenant.clean
+          opam config exec -- make test
+        env:
+          DATABASE_URL: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@0.0.0.0:3306/${{ env.MYSQL_DATABASE }}
+          DATABASE_URL_TENANT_ONE: mariadb://root:${{ env.MYSQL_ROOT_PASSWORD }}@0.0.0.0:3307/${{ env.MYSQL_DATABASE }}
+          SIHL_ENV: test
+          SMTP_SENDER: test@econ.uzh.ch
+          TEST_EMAIL: test@econ.uzh.ch
+
       - uses: actions/upload-artifact@v3
         with:
           name: pool.exe


### PR DESCRIPTION
Just that, CI should be much faster since setup-ocaml will automatically reuse the opam and dune caches across builds.