### PR TITLE
add pattern validation for phone number

### DIFF
--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -790,7 +790,8 @@ let cell_phone_input ?(required = false) () =
             ~a:
               ([ a_name Pool_common.Message.Field.(show CellPhone)
                ; a_class [ "input" ]
-               ; a_input_type `Number
+               ; a_input_type `Text
+               ; a_pattern "^[1-9]\d{3,12}"
                ; a_placeholder "791234567"
                ]
                @ attrs)


### PR DESCRIPTION
- add pattern for phone number between 4 and 13 digits without country code (don't allow starting with 0)