### PR TITLE
feat(1995): Move rest of the tables to the new Sorting Tables

### DIFF
--- a/pool/app/contact/contact.mli
+++ b/pool/app/contact/contact.mli
@@ -239,6 +239,9 @@ val searchable_by : Query.Column.t list
 val sortable_by : Query.Column.t list
 val default_sort : Query.Sort.t
 val default_query : Query.t
+val column_first_name : Query.Column.t
+val column_last_name : Query.Column.t
+val column_email : Query.Column.t
 
 module Repo : sig
   module Preview : sig

--- a/pool/app/contact/entity.ml
+++ b/pool/app/contact/entity.ml
@@ -207,8 +207,19 @@ end
 
 let profile_completion_cookie = "profile_completion"
 
+open Pool_common.Message
+
+let column_email = (Field.Email, "user_users.email") |> Query.Column.create
+
+let column_first_name =
+  (Field.Firstname, "user_users.given_name") |> Query.Column.create
+;;
+
+let column_last_name =
+  (Field.Lastname, "user_users.name") |> Query.Column.create
+;;
+
 let searchable_and_sortable_by =
-  let open Pool_common.Message in
   [ Field.Email, "user_users.email"
   ; Field.Firstname, "user_users.given_name"
   ; Field.Lastname, "user_users.name"

--- a/pool/app/email/dune
+++ b/pool/app/email/dune
@@ -6,6 +6,7 @@
   pool_database
   pool_tenant
   pool_user
+  query
   service
   utils)
  (preprocess

--- a/pool/app/email/email.mli
+++ b/pool/app/email/email.mli
@@ -207,6 +207,16 @@ module SmtpAuth : sig
 
   val find_default_opt : Pool_database.Label.t -> t option Lwt.t
   val find_all : Pool_database.Label.t -> t list Lwt.t
+  val find_by : Query.t -> Pool_database.Label.t -> (t list * Query.t) Lwt.t
+  val column_label : Query.Column.t
+  val column_smtp_server : Query.Column.t
+  val column_smtp_username : Query.Column.t
+  val column_smtp_mechanism : Query.Column.t
+  val column_smtp_protocol : Query.Column.t
+  val column_smtp_default_account : Query.Column.t
+  val default_query : Query.t
+  val searchable_by : Query.Column.t list
+  val sortable_by : Query.Column.t list
 end
 
 type job =

--- a/pool/app/email/entity_smtp.ml
+++ b/pool/app/email/entity_smtp.ml
@@ -141,3 +141,51 @@ module Write = struct
     }
   ;;
 end
+
+open Pool_common.Message
+
+let column_label = (Field.Label, "pool_smtp.label") |> Query.Column.create
+
+let column_smtp_server =
+  (Field.SmtpServer, "pool_smtp.server") |> Query.Column.create
+;;
+
+let column_smtp_username =
+  (Field.SmtpUsername, "pool_smtp.username") |> Query.Column.create
+;;
+
+let column_smtp_mechanism =
+  (Field.SmtpMechanism, "pool_smtp.mechanism") |> Query.Column.create
+;;
+
+let column_smtp_protocol =
+  (Field.SmtpProtocol, "pool_smtp.protocol") |> Query.Column.create
+;;
+
+let column_smtp_default_account =
+  (Field.DefaultSmtpServer, "pool_smtp.default_account") |> Query.Column.create
+;;
+
+let column_created_at =
+  (Field.CreatedAt, "pool_smtp.created_at") |> Query.Column.create
+;;
+
+let searchable_by =
+  [ column_label
+  ; column_smtp_server
+  ; column_smtp_username
+  ; column_smtp_mechanism
+  ; column_smtp_protocol
+  ]
+;;
+
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/app/email/repo/repo.ml
+++ b/pool/app/email/repo/repo.ml
@@ -11,6 +11,7 @@ let delete_unverified_by_user = Repo_sql.delete_unverified_by_user
 module Smtp = struct
   let find = Sql.Smtp.find
   let find_by_label = Sql.Smtp.find_by_label
+  let find_by = Sql.Smtp.find_by
   let find_full = Sql.Smtp.find_full
   let find_full_default = Sql.Smtp.find_full_default
 

--- a/pool/app/email/repo/repo_sql.ml
+++ b/pool/app/email/repo/repo_sql.ml
@@ -316,8 +316,8 @@ module Smtp = struct
     Query.collect_and_count
       pool
       (Some query)
-      ~select:select_smtp_sql
-      ~count:select_count
+      ~select:(fun ?(count = false) fragment ->
+        if count then select_count fragment else select_smtp_sql fragment)
       RepoEntity.SmtpAuth.t
   ;;
 

--- a/pool/app/email/repo/repo_sql.ml
+++ b/pool/app/email/repo/repo_sql.ml
@@ -302,6 +302,25 @@ module Smtp = struct
     Utils.Database.collect (Pool_database.Label.value pool) find_all_request ()
   ;;
 
+  let select_count where_fragment =
+    Format.asprintf
+      {sql|
+        SELECT COUNT(*)
+        FROM pool_smtp
+        %s
+      |sql}
+      where_fragment
+  ;;
+
+  let find_by query pool =
+    Query.collect_and_count
+      pool
+      (Some query)
+      ~select:select_smtp_sql
+      ~count:select_count
+      RepoEntity.SmtpAuth.t
+  ;;
+
   let unset_default_flags pool =
     let open Caqti_request.Infix in
     let request =

--- a/pool/app/filter/entity.ml
+++ b/pool/app/filter/entity.ml
@@ -737,3 +737,23 @@ type base_condition =
   | Matcher of Pool_common.Id.t
   | MatcherReset of Pool_common.Id.t * Ptime.t
 [@@deriving eq, show]
+
+open Pool_common.Message
+
+let column_title = (Field.Title, "pool_filter.title") |> Query.Column.create
+
+let column_created_at =
+  (Field.CreatedAt, "pool_filter.created_at") |> Query.Column.create
+;;
+
+let searchable_by = [ column_title ]
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/app/filter/filter.ml
+++ b/pool/app/filter/filter.ml
@@ -5,6 +5,7 @@ module Human = Entity_human
 module UtilsF = Filter_utils
 
 let find = Repo.find
+let find_by = Repo.find_by
 let find_all_templates = Repo.find_all_templates
 let find_template = Repo.find_template
 let find_templates_of_query = Repo.find_templates_of_query

--- a/pool/app/filter/filter.mli
+++ b/pool/app/filter/filter.mli
@@ -197,6 +197,7 @@ val find
   -> (t, Pool_common.Message.error) result Lwt.t
 
 val find_all_templates : Pool_database.Label.t -> unit -> t list Lwt.t
+val find_by : Query.t -> Pool_database.Label.t -> (t list * Query.t) Lwt.t
 
 val find_template
   :  Pool_database.Label.t
@@ -312,3 +313,8 @@ module Guard : sig
     val delete : Id.t -> Guard.ValidationSet.t
   end
 end
+
+val column_title : Query.Column.t
+val default_query : Query.t
+val searchable_by : Query.Column.t list
+val sortable_by : Query.Column.t list

--- a/pool/app/filter/repo/repo.ml
+++ b/pool/app/filter/repo/repo.ml
@@ -556,9 +556,32 @@ module Sql = struct
     ||> CCOption.value ~default:0
     ||> CCResult.return
   ;;
+
+  let select_count where_fragment =
+    Format.asprintf
+      {sql|
+        SELECT COUNT(*)
+        FROM pool_filter
+        %s
+      |sql}
+      where_fragment
+  ;;
+
+  let find_by query pool =
+    let select fragment =
+      select_filter_sql component_base_query ^ "  " ^ fragment
+    in
+    Query.collect_and_count
+      pool
+      (Some query)
+      ~select
+      ~count:select_count
+      Repo_entity.t
+  ;;
 end
 
 let find = Sql.find
+let find_by = Sql.find_by
 let find_all_templates = Sql.find_all_templates
 let find_template = Sql.find_template
 let find_multiple_templates = Sql.find_multiple_templates

--- a/pool/app/filter/repo/repo.ml
+++ b/pool/app/filter/repo/repo.ml
@@ -568,15 +568,12 @@ module Sql = struct
   ;;
 
   let find_by query pool =
-    let select fragment =
-      select_filter_sql component_base_query ^ "  " ^ fragment
+    let select ?(count = false) fragment =
+      if count
+      then select_count fragment
+      else select_filter_sql component_base_query ^ "  " ^ fragment
     in
-    Query.collect_and_count
-      pool
-      (Some query)
-      ~select
-      ~count:select_count
-      Repo_entity.t
+    Query.collect_and_count pool (Some query) ~select Repo_entity.t
   ;;
 end
 

--- a/pool/app/guard/dune
+++ b/pool/app/guard/dune
@@ -8,6 +8,7 @@
   pool_common
   pool_database
   role
+  query
   sihl
   utils)
  (preprocess

--- a/pool/app/guard/guard.ml
+++ b/pool/app/guard/guard.ml
@@ -193,3 +193,10 @@ module Access = struct
   let manage_role = one_of_tuple (Manage, `Role, None)
   let manage_permission = one_of_tuple (Manage, `Permission, None)
 end
+
+let column_role = Repo.column_role
+let column_model = Repo.column_model
+let column_action = Repo.column_action
+let searchable_by = Repo.searchable_by
+let sortable_by = Repo.sortable_by
+let default_query = Repo.default_query

--- a/pool/app/guard/repo.ml
+++ b/pool/app/guard/repo.ml
@@ -25,19 +25,19 @@ module RolePermission = struct
      |sql}
   ;;
 
-  let select fragment =
-    Format.sprintf
-      "SELECT\n  %s\nFROM  %s\n  WHERE\n  %s\n %s"
-      select_sql
-      from_sql
-      std_filter_sql
-      fragment
-  ;;
-
-  let count fragment =
-    Format.sprintf
-      {sql| SELECT COUNT(*) from guardian_role_permissions %s |sql}
-      fragment
+  let select ?(count = false) fragment =
+    if count
+    then
+      Format.sprintf
+        {sql| SELECT COUNT(*) from guardian_role_permissions %s |sql}
+        fragment
+    else
+      Format.sprintf
+        "SELECT\n  %s\nFROM  %s\n  WHERE\n  %s\n %s"
+        select_sql
+        from_sql
+        std_filter_sql
+        fragment
   ;;
 
   let find_by query pool =
@@ -45,7 +45,6 @@ module RolePermission = struct
       pool
       (Some query)
       ~select
-      ~count
       Backend.Entity.RolePermission.t
   ;;
 end

--- a/pool/app/organisational_unit/dune
+++ b/pool/app/organisational_unit/dune
@@ -1,6 +1,6 @@
 (library
  (name organisational_unit)
- (libraries guard pool_common pool_tenant sihl)
+ (libraries guard pool_common pool_tenant query sihl)
  (preprocess
   (pps
    lwt_ppx

--- a/pool/app/organisational_unit/entity.ml
+++ b/pool/app/organisational_unit/entity.ml
@@ -14,3 +14,26 @@ type t =
 [@@deriving eq, show]
 
 let create ?(id = Id.create ()) name = { id; name }
+
+open Pool_common.Message
+
+let column_name =
+  (Field.Name, "pool_organisational_units.name") |> Query.Column.create
+;;
+
+let column_created_at =
+  (Field.CreatedAt, "pool_organisational_units.created_at")
+  |> Query.Column.create
+;;
+
+let searchable_by = [ column_name ]
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/app/organisational_unit/organisational_unit.ml
+++ b/pool/app/organisational_unit/organisational_unit.ml
@@ -4,6 +4,7 @@ module Guard = Entity_guard
 
 let find = Repo.find
 let all = Repo.all
+let find_by = Repo.find_by
 
 module Repo = struct
   let sql_select_columns = Repo.sql_select_columns

--- a/pool/app/organisational_unit/organisational_unit.mli
+++ b/pool/app/organisational_unit/organisational_unit.mli
@@ -52,6 +52,7 @@ val find
   -> Id.t
   -> (t, Pool_common.Message.error) result Lwt.t
 
+val find_by : Query.t -> Pool_database.Label.t -> (t list * Query.t) Lwt.t
 val all : Pool_database.Label.t -> unit -> t list Lwt.t
 
 module Repo : sig
@@ -63,3 +64,8 @@ module Repo : sig
 
   val t : t Caqti_type.t
 end
+
+val column_name : Query.Column.t
+val default_query : Query.t
+val searchable_by : Query.Column.t list
+val sortable_by : Query.Column.t list

--- a/pool/app/organisational_unit/repo.ml
+++ b/pool/app/organisational_unit/repo.ml
@@ -107,6 +107,8 @@ let select_count where_fragment =
 ;;
 
 let find_by query pool =
-  let select fragment = select_from ^ "  " ^ fragment in
-  Query.collect_and_count pool (Some query) ~select ~count:select_count t
+  let select ?(count = false) fragment =
+    if count then select_count fragment else select_from ^ "  " ^ fragment
+  in
+  Query.collect_and_count pool (Some query) ~select t
 ;;

--- a/pool/app/organisational_unit/repo.ml
+++ b/pool/app/organisational_unit/repo.ml
@@ -95,3 +95,18 @@ let update_request =
 let update pool =
   Utils.Database.exec (Pool_database.Label.value pool) update_request
 ;;
+
+let select_count where_fragment =
+  Format.asprintf
+    {sql|
+        SELECT COUNT(*)
+        FROM pool_organisational_units
+        %s
+      |sql}
+    where_fragment
+;;
+
+let find_by query pool =
+  let select fragment = select_from ^ "  " ^ fragment in
+  Query.collect_and_count pool (Some query) ~select ~count:select_count t
+;;

--- a/pool/app/pool_location/dune
+++ b/pool/app/pool_location/dune
@@ -8,6 +8,7 @@
   pool_database
   pool_tenant
   service
+  query
   sihl
   utils)
  (preprocess

--- a/pool/app/pool_location/entity.ml
+++ b/pool/app/pool_location/entity.ml
@@ -155,3 +155,29 @@ module Human = struct
     CCOption.bind description (Description.find_opt langauge)
   ;;
 end
+
+let column_name = (Field.Name, "pool_locations.name") |> Query.Column.create
+
+let column_location =
+  (Field.Location, "pool_locations.location") |> Query.Column.create
+;;
+
+let column_description =
+  (Field.Description, "pool_locations.description") |> Query.Column.create
+;;
+
+let column_created_at =
+  (Field.CreatedAt, "pool_locations.created_at") |> Query.Column.create
+;;
+
+let searchable_by = [ column_name; column_location; column_description ]
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/app/pool_location/pool_location.ml
+++ b/pool/app/pool_location/pool_location.ml
@@ -6,6 +6,7 @@ module Guard = Entity_guard
 
 let find = Repo.find
 let find_all = Repo.find_all
+let find_by = Repo.find_by
 let find_location_file = Repo_file_mapping.find
 let search = Repo.search
 let search_multiple_by_id = Repo.search_multiple_by_id

--- a/pool/app/pool_location/pool_location.mli
+++ b/pool/app/pool_location/pool_location.mli
@@ -282,6 +282,7 @@ val find
   -> (t, Pool_common.Message.error) Lwt_result.t
 
 val find_all : Pool_database.Label.t -> t list Lwt.t
+val find_by : Query.t -> Pool_database.Label.t -> (t list * Query.t) Lwt.t
 
 val find_location_file
   :  Pool_database.Label.t
@@ -361,3 +362,10 @@ module Guard : sig
     end
   end
 end
+
+val column_name : Query.Column.t
+val column_description : Query.Column.t
+val column_location : Query.Column.t
+val default_query : Query.t
+val searchable_by : Query.Column.t list
+val sortable_by : Query.Column.t list

--- a/pool/app/pool_location/repo/repo.ml
+++ b/pool/app/pool_location/repo/repo.ml
@@ -285,8 +285,10 @@ let find_by query pool =
     Query.collect_and_count
       pool
       (Some query)
-      ~select:(fun fragment -> Format.sprintf "%s %s" Sql.select_sql fragment)
-      ~count:Sql.select_count
+      ~select:(fun ?(count = false) fragment ->
+        if count
+        then Sql.select_count fragment
+        else Format.sprintf "%s %s" Sql.select_sql fragment)
       t
   in
   let* locations = Lwt_list.map_s (files_to_location pool) locations in

--- a/pool/app/tags/entity.ml
+++ b/pool/app/tags/entity.ml
@@ -62,3 +62,28 @@ module Tagged = struct
 
   let create model_uuid tag_uuid = Ok { model_uuid; tag_uuid }
 end
+
+open Pool_common.Message
+
+let column_title = (Field.Title, "pool_tags.title") |> Query.Column.create
+let column_model = (Field.Model, "pool_tags.model") |> Query.Column.create
+
+let column_description =
+  (Field.Description, "pool_tags.description") |> Query.Column.create
+;;
+
+let column_created_at =
+  (Field.CreatedAt, "pool_tags.created_at") |> Query.Column.create
+;;
+
+let searchable_by = [ column_title; column_model; column_description ]
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/app/tags/repo.ml
+++ b/pool/app/tags/repo.ml
@@ -187,13 +187,10 @@ module Sql = struct
   ;;
 
   let find_by query pool =
-    let select fragment = select_tag_sql ^ "  " ^ fragment in
-    Query.collect_and_count
-      pool
-      (Some query)
-      ~select
-      ~count:select_count
-      RepoEntity.t
+    let select ?(count = false) fragment =
+      if count then select_count fragment else select_tag_sql ^ "  " ^ fragment
+    in
+    Query.collect_and_count pool (Some query) ~select RepoEntity.t
   ;;
 
   let find_all_with_model_request =

--- a/pool/app/tags/repo.ml
+++ b/pool/app/tags/repo.ml
@@ -176,6 +176,26 @@ module Sql = struct
     Utils.Database.collect (Label.value pool) find_all_request ()
   ;;
 
+  let select_count where_fragment =
+    Format.asprintf
+      {sql|
+        SELECT COUNT(*)
+        FROM pool_tags
+        %s
+      |sql}
+      where_fragment
+  ;;
+
+  let find_by query pool =
+    let select fragment = select_tag_sql ^ "  " ^ fragment in
+    Query.collect_and_count
+      pool
+      (Some query)
+      ~select
+      ~count:select_count
+      RepoEntity.t
+  ;;
+
   let find_all_with_model_request =
     Format.asprintf
       {sql|
@@ -441,6 +461,7 @@ let find_all_with_model = Sql.find_all_with_model
 let find_all_validated = Sql.find_all_validated
 let find_all_validated_with_model = Sql.find_all_validated_with_model
 let find_all_of_entity = Sql.Tagged.find_all_of_entity
+let find_by = Sql.find_by
 let create_find_all_tag_sql = Sql.Tagged.create_find_all_tag_sql
 let already_exists = Sql.already_exists
 let insert = Sql.insert

--- a/pool/app/tags/tags.mli
+++ b/pool/app/tags/tags.mli
@@ -105,6 +105,7 @@ val search_by_title
 
 val find_all : Pool_database.Label.t -> t list Lwt.t
 val find_all_with_model : Pool_database.Label.t -> Model.t -> t list Lwt.t
+val find_by : Query.t -> Pool_database.Label.t -> (t list * Query.t) Lwt.t
 
 val find_all_of_entity
   :  Pool_database.Label.t
@@ -189,3 +190,10 @@ end
 module Sql : sig
   val select_tag_sql : string
 end
+
+val column_title : Query.Column.t
+val column_description : Query.Column.t
+val column_model : Query.Column.t
+val default_query : Query.t
+val searchable_by : Query.Column.t list
+val sortable_by : Query.Column.t list

--- a/pool/schedule/entity.ml
+++ b/pool/schedule/entity.ml
@@ -105,3 +105,35 @@ let is_ok ({ scheduled_time; status; last_run; _ } : public) =
   in
   is_fine status || did_run ()
 ;;
+
+open Pool_common.Message
+
+let column_label = (Field.Label, "pool_schedules.label") |> Query.Column.create
+
+let column_scheduled_time =
+  (Field.ScheduledTime, "pool_schedules.scheduled_time") |> Query.Column.create
+;;
+
+let column_status =
+  (Field.Status, "pool_schedules.status") |> Query.Column.create
+;;
+
+let column_last_run_at =
+  (Field.LastRunAt, "pool_schedules.last_run_at") |> Query.Column.create
+;;
+
+let column_created_at =
+  (Field.CreatedAt, "pool_schedules.created_at") |> Query.Column.create
+;;
+
+let searchable_by = [ column_label ]
+let default_sort_column = column_created_at
+let sortable_by = default_sort_column :: searchable_by
+
+let default_query =
+  let open Query in
+  let sort =
+    Sort.{ column = default_sort_column; order = SortOrder.Descending }
+  in
+  create ~sort ()
+;;

--- a/pool/schedule/repo.ml
+++ b/pool/schedule/repo.ml
@@ -170,8 +170,8 @@ module Sql = struct
     Query.collect_and_count
       pool
       (Some query)
-      ~select:select_fragment
-      ~count:select_count
+      ~select:(fun ?(count = false) fragment ->
+        if count then select_count fragment else select_fragment fragment)
       public
   ;;
 end

--- a/pool/schedule/schedule.ml
+++ b/pool/schedule/schedule.ml
@@ -152,3 +152,4 @@ let add_and_start schedule =
 ;;
 
 let find_all = Repo.find_all
+let find_by = Repo.find_by

--- a/pool/schedule/schedule.mli
+++ b/pool/schedule/schedule.mli
@@ -54,9 +54,18 @@ val lifecycle : Sihl.Container.lifecycle
 val register : ?schedules:t list -> unit -> Sihl.Container.Service.t
 val is_ok : public -> bool
 val find_all : unit -> public list Lwt.t
+val find_by : Query.t -> (public list * Query.t) Lwt.t
 
 module Guard : sig
   module Access : sig
     val index : Guard.ValidationSet.t
   end
 end
+
+val column_label : Query.Column.t
+val column_scheduled_time : Query.Column.t
+val column_status : Query.Column.t
+val column_last_run_at : Query.Column.t
+val default_query : Query.t
+val searchable_by : Query.Column.t list
+val sortable_by : Query.Column.t list

--- a/pool/web/handler/admin_settings_schedule.ml
+++ b/pool/web/handler/admin_settings_schedule.ml
@@ -1,19 +1,19 @@
-open Utils.Lwt_result.Infix
 module HttpUtils = Http_utils
 module Message = HttpUtils.Message
 
 let src = Logs.Src.create "handler.admin.settings_schedule"
 let active_navigation = "/admin/settings/schedules"
 
-let show req =
-  let result context =
-    Schedule.find_all ()
-    ||> Page.Admin.Settings.Schedule.index context
-    >|> General.create_tenant_layout req ~active_navigation context
-    >|+ Sihl.Web.Response.of_html
-    >|- fun err -> err, "/"
-  in
-  result |> HttpUtils.extract_happy_path ~src req
+let show =
+  Http_utils.Htmx.handler
+    ~active_navigation
+    ~error_path:active_navigation
+    ~query:(module Schedule)
+    ~create_layout:General.create_tenant_layout
+  @@ fun context query ->
+  let%lwt schedules, query = Schedule.find_by query in
+  let page = Page.Admin.Settings.Schedule.index context schedules query in
+  Lwt.return (Ok page)
 ;;
 
 module Access : module type of Helpers.Access = struct

--- a/pool/web/view/component/sortable_table.mli
+++ b/pool/web/view/component/sortable_table.mli
@@ -28,12 +28,14 @@ type sort =
 type col =
   [ `column of Query.Column.t
   | `custom of [ | Html_types.flow5 ] Tyxml_html.elt
+  | `field of Pool_common.Message.Field.t * Query.Column.t
+  | `empty
   ]
 
 val make
   :  ?layout:[ `Striped | `Simple ]
   -> ?align_last_end:bool
-  -> id:string
+  -> target_id:string
   -> cols:col list
   -> rows:[< Html_types.td_content_fun ] Tyxml_html.elt list list
   -> sort

--- a/pool/web/view/htmx/dune
+++ b/pool/web/view/htmx/dune
@@ -1,5 +1,5 @@
 (library
  (name htmx)
- (libraries custom_field component http_utils service sihl tyxml)
+ (libraries custom_field component service sihl tyxml)
  (preprocess
   (pps lwt_ppx ppx_deriving.eq ppx_deriving.show ppx_variants_conv)))

--- a/pool/web/view/htmx/htmx.ml
+++ b/pool/web/view/htmx/htmx.ml
@@ -3,15 +3,6 @@ module Version = Pool_common.Version
 module User = Pool_user
 module Input = Component.Input
 
-let hx_request_header = "Hx-Request"
-
-let is_hx_request req =
-  let headers = Rock.Request.(req.headers) in
-  match Httpaf.Headers.get headers hx_request_header with
-  | Some "true" -> true
-  | _ -> false
-;;
-
 let hx_trigger = a_user_data "hx-trigger"
 let hx_post = a_user_data "hx-post"
 let hx_get = a_user_data "hx-get"

--- a/pool/web/view/page/page_admin_contact.ml
+++ b/pool/web/view/page/page_admin_contact.ml
@@ -1,3 +1,4 @@
+open Containers
 open CCFun
 open Tyxml.Html
 module Table = Component.Table
@@ -331,13 +332,33 @@ let contact_overview language contacts =
     contacts
 ;;
 
-let index Pool_context.{ language; _ } contacts =
+let index Pool_context.{ language; _ } contacts query =
+  let open Pool_user in
+  let open Pool_common in
+  let url = Uri.of_string "/admin/contacts" in
+  let sort = Component.Sortable_table.{ url; query; language } in
+  let cols =
+    [ `field (Message.Field.Name, Contact.column_first_name)
+    ; `column Contact.column_email
+    ; `empty
+    ]
+  in
+  let rows =
+    let row (contact : Contact.t) =
+      [ Component.Contacts.identity_with_icons true contact
+      ; txt (EmailAddress.value (Contact.email_address contact))
+      ; Input.link_as_button ~icon:Icon.Eye (path contact)
+      ]
+    in
+    CCList.map row contacts
+  in
+  let target_id = "contacts-list" in
   div
-    ~a:[ a_class [ "trim"; "safety-margin" ] ]
+    ~a:[ a_id target_id; a_class [ "trim"; "safety-margin" ] ]
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
         [ txt Pool_common.(Utils.nav_link_to_string language I18n.Contacts) ]
-    ; contact_overview language contacts
+    ; Component.Sortable_table.make ~target_id ~cols ~rows sort
     ]
 ;;
 

--- a/pool/web/view/page/page_admin_contact.ml
+++ b/pool/web/view/page/page_admin_contact.ml
@@ -291,47 +291,6 @@ let assign_contact_form { Pool_context.csrf; language; _ } contact =
     ]
 ;;
 
-let contact_overview language contacts =
-  let open Contact in
-  let open Pool_user in
-  let thead =
-    (Pool_common.Message.Field.[ Name; Email ] |> Table.fields_to_txt language)
-    @ [ txt "" ]
-  in
-  let user_table contacts =
-    let rows =
-      CCList.map
-        (fun contact ->
-          let row =
-            match contact.disabled |> Disabled.value with
-            | true -> tr ~a:[ a_class [ "bg-red-lighter" ] ]
-            | false -> tr ~a:[]
-          in
-          [ Component.Contacts.identity_with_icons true contact
-          ; Component.Contacts.email_with_icons contact
-          ; contact |> path |> Input.link_as_button ~icon:Icon.Eye
-          ]
-          |> CCList.map (fun cell -> td [ cell ])
-          |> row)
-        contacts
-    in
-    let thead = Table.table_head thead in
-    table
-      ~thead
-      ~a:[ a_class (Table.table_classes `Striped ~align_last_end:true ()) ]
-      rows
-  in
-  Component.List.create
-    ~legend:
-      (Component.Contacts.status_icons_table_legend language `All
-       |> Component.Table.table_legend)
-    language
-    user_table
-    Contact.sortable_by
-    Contact.searchable_by
-    contacts
-;;
-
 let index Pool_context.{ language; _ } contacts query =
   let open Pool_user in
   let open Pool_common in
@@ -358,7 +317,15 @@ let index Pool_context.{ language; _ } contacts query =
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
         [ txt Pool_common.(Utils.nav_link_to_string language I18n.Contacts) ]
-    ; Component.Sortable_table.make ~target_id ~cols ~rows sort
+    ; Component.List.create
+        ~legend:
+          (Component.Contacts.status_icons_table_legend language `All
+           |> Component.Table.table_legend)
+        language
+        (fun _ -> Component.Sortable_table.make ~target_id ~cols ~rows sort)
+        Contact.sortable_by
+        Contact.searchable_by
+        (contacts, query)
     ]
 ;;
 

--- a/pool/web/view/page/page_admin_experiments.ml
+++ b/pool/web/view/page/page_admin_experiments.ml
@@ -122,7 +122,7 @@ let message_templates_html
     edit_path
 ;;
 
-let index Pool_context.{ language; _ } ?(with_search = true) experiments query =
+let index Pool_context.{ language; _ } experiments query =
   let url = Uri.of_string "/admin/experiments" in
   let sort = Sortable_table.{ url; query; language } in
   let cols =
@@ -151,23 +151,21 @@ let index Pool_context.{ language; _ } ?(with_search = true) experiments query =
     in
     CCList.map row experiments
   in
-  let table = Sortable_table.make ~id:"experiment-list" ~cols ~rows sort in
-  if with_search
-  then
-    div
-      ~a:[ a_class [ "trim"; "safety-margin" ] ]
-      [ h1
-          ~a:[ a_class [ "heading-1" ] ]
-          [ txt (Utils.text_to_string language I18n.ExperimentListTitle) ]
-      ; List.create
-          ~hide_sort:true
-          language
-          (fun _ -> table)
-          Experiment.sortable_by
-          Experiment.searchable_by
-          (experiments, query)
-      ]
-  else table
+  let target_id = "experiment-list" in
+  let table = Sortable_table.make ~target_id ~cols ~rows sort in
+  div
+    ~a:[ a_id target_id; a_class [ "trim"; "safety-margin" ] ]
+    [ h1
+        ~a:[ a_class [ "heading-1" ] ]
+        [ txt (Utils.text_to_string language I18n.ExperimentListTitle) ]
+    ; List.create
+        ~hide_sort:true
+        language
+        (fun _ -> table)
+        Experiment.sortable_by
+        Experiment.searchable_by
+        (experiments, query)
+    ]
 ;;
 
 let experiment_form

--- a/pool/web/view/page/page_admin_filter.ml
+++ b/pool/web/view/page/page_admin_filter.ml
@@ -1,35 +1,41 @@
+open Containers
 open Tyxml.Html
+open Pool_common
 
-let index { Pool_context.language; _ } filter_list =
-  let thead =
-    Pool_common.Message.
-      [ Field.Title |> Component.Table.field_to_txt language
-      ; Component.Input.link_as_button
-          ~style:`Success
-          ~icon:Component.Icon.Add
-          ~classnames:[ "small" ]
-          ~control:(language, Pool_common.Message.(Add (Some Field.Filter)))
-          "/admin/filter/new"
+let index { Pool_context.language; _ } filter_list query =
+  let url = Uri.of_string "/admin/filter" in
+  let sort = Component.Sortable_table.{ url; query; language } in
+  let cols =
+    let create_filter : [ | Html_types.flow5 ] elt =
+      Component.Input.link_as_button
+        ~style:`Success
+        ~icon:Component.Icon.Add
+        ~classnames:[ "small" ]
+        ~control:(language, Message.(Add (Some Field.Filter)))
+        "/admin/filter/new"
+    in
+    [ `column Filter.column_title; `custom create_filter ]
+  in
+  let rows =
+    let open Filter in
+    let row (filter : Filter.t) =
+      let title = Option.map Title.value filter.title in
+      [ txt (Option.get_or ~default:"" title)
+      ; Format.asprintf "/admin/filter/%s/edit" (Filter.Id.value filter.id)
+        |> Component.Input.edit_link
       ]
+    in
+    CCList.map row filter_list
   in
   div
-    ~a:[ a_class [ "trim"; "measure"; "safety-margin" ] ]
+    ~a:[ a_id "filters-list"; a_class [ "trim"; "measure"; "safety-margin" ] ]
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
         [ txt
             (Pool_common.(Utils.field_to_string language Message.Field.Filter)
              |> CCString.capitalize_ascii)
         ]
-    ; CCList.map
-        (fun filter ->
-          [ txt Filter.(filter.title |> CCOption.map_or ~default:"" Title.value)
-          ; filter.Filter.id
-            |> Pool_common.Id.value
-            |> Format.asprintf "/admin/filter/%s/edit"
-            |> Component.Input.edit_link
-          ])
-        filter_list
-      |> Component.Table.horizontal_table `Striped ~align_last_end:true ~thead
+    ; Component.Sortable_table.make ~target_id:"filters-list" ~cols ~rows sort
     ]
 ;;
 

--- a/pool/web/view/page/page_admin_organisational_units.ml
+++ b/pool/web/view/page/page_admin_organisational_units.ml
@@ -16,28 +16,6 @@ let ou_path ?suffix ?id () =
   CCOption.map_or ~default (Format.asprintf "%s/%s" default) suffix
 ;;
 
-module List = struct
-  let row { Organisational_unit.id; name } =
-    Organisational_unit.
-      [ txt (Name.value name); Input.edit_link (ou_path ~id ~suffix:"edit" ()) ]
-  ;;
-
-  let create { Pool_context.language; _ } organisational_units =
-    let open Pool_common in
-    let thead =
-      (Message.Field.[ Name ] |> Component.Table.fields_to_txt language)
-      @ [ Input.link_as_button
-            ~style:`Success
-            ~icon:Icon.Add
-            ~control:(language, Message.(Add (Some Field.OrganisationalUnit)))
-            (ou_path ~suffix:"create" ())
-        ]
-    in
-    CCList.map row organisational_units
-    |> Component.Table.horizontal_table `Striped ~thead ~align_last_end:true
-  ;;
-end
-
 let form { Pool_context.language; csrf; _ } organisational_unit =
   let open Organisational_unit in
   let open Pool_common in
@@ -69,15 +47,38 @@ let form { Pool_context.language; csrf; _ } organisational_unit =
     ]
 ;;
 
-let index ({ Pool_context.language; _ } as context) organisational_units =
+let index { Pool_context.language; _ } organizations query =
+  let open Pool_common in
+  let url = Uri.of_string (ou_path ()) in
+  let sort = Component.Sortable_table.{ url; query; language } in
+  let cols =
+    let create_btn : [ | Html_types.flow5 ] elt =
+      Component.Input.link_as_button
+        ~style:`Success
+        ~icon:Icon.Add
+        ~control:(language, Message.(Add (Some Field.OrganisationalUnit)))
+        (ou_path ~suffix:"create" ())
+    in
+    [ `column Organisational_unit.column_name; `custom create_btn ]
+  in
+  let rows =
+    let open Organisational_unit in
+    let row (org : Organisational_unit.t) =
+      [ txt (Name.value org.name)
+      ; Component.Input.edit_link (ou_path ~id:org.id ~suffix:"edit" ())
+      ]
+    in
+    CCList.map row organizations
+  in
+  let target_id = "organisations-table" in
   div
-    ~a:[ a_class [ "trim"; "safety-margin" ] ]
+    ~a:[ a_id target_id; a_class [ "trim"; "safety-margin" ] ]
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
         [ txt
             Pool_common.(
               Utils.nav_link_to_string language I18n.OrganisationalUnits)
         ]
-    ; List.create context organisational_units
+    ; Component.Sortable_table.make ~target_id ~cols ~rows sort
     ]
 ;;

--- a/pool/web/view/page/page_admin_settings_schedule.ml
+++ b/pool/web/view/page/page_admin_settings_schedule.ml
@@ -1,19 +1,25 @@
+open Containers
 open CCFun
 open Tyxml.Html
 module HttpUtils = Http_utils
 
-let schedule_overview language schedules =
+let index Pool_context.{ language; _ } schedules query =
+  let target_id = "schedule-table" in
   let open Pool_common in
-  let thead =
-    Message.Field.[ Label; ScheduledTime; Status; LastRunAt ]
-    |> Component.Table.fields_to_txt language
+  let url = Uri.of_string "/admin/settings/schedules" in
+  let sort = Component.Sortable_table.{ url; query; language } in
+  let cols =
+    [ `column Schedule.column_label
+    ; `column Schedule.column_scheduled_time
+    ; `column Schedule.column_status
+    ; `column Schedule.column_last_run_at
+    ]
   in
-  CCList.map
-    (fun ({ Schedule.label; status; scheduled_time; last_run } :
-           Schedule.public) ->
-      let open Schedule in
+  let rows =
+    let open Schedule in
+    let row (schedule : Schedule.public) =
       let scheduled =
-        match scheduled_time with
+        match schedule.scheduled_time with
         | Every span ->
           Utils.hint_to_string
             language
@@ -23,23 +29,21 @@ let schedule_overview language schedules =
             language
             (I18n.ScheduleAt (ScheduledTime.value time))
       in
-      [ txt (Label.value label)
+      [ txt (Label.value schedule.label)
       ; txt scheduled
-      ; txt (Status.show status)
+      ; txt (Status.show schedule.status)
       ; txt
-          (last_run
+          (schedule.last_run
            |> CCOption.map_or
                 ~default:"---"
                 (LastRunAt.value %> Pool_common.Utils.Time.formatted_date_time)
           )
-      ])
-    schedules
-  |> Component.Table.horizontal_table `Striped ~align_last_end:true ~thead
-;;
-
-let index Pool_context.{ language; _ } schedules =
+      ]
+    in
+    List.map row schedules
+  in
   div
-    ~a:[ a_class [ "trim"; "safety-margin" ] ]
+    ~a:[ a_id target_id; a_class [ "trim"; "safety-margin" ] ]
     [ h1
         ~a:[ a_class [ "heading-1" ] ]
         [ txt Pool_common.(Utils.nav_link_to_string language I18n.Schedules) ]
@@ -47,6 +51,6 @@ let index Pool_context.{ language; _ } schedules =
         [ Pool_common.(Utils.hint_to_string language I18n.ScheduledIntro)
           |> HttpUtils.add_line_breaks
         ]
-    ; schedule_overview language schedules
+    ; Component.Sortable_table.make ~target_id ~cols ~rows sort
     ]
 ;;

--- a/pool/web/view/page/page_admin_settings_tags.ml
+++ b/pool/web/view/page/page_admin_settings_tags.ml
@@ -1,3 +1,4 @@
+open Containers
 open Tyxml.Html
 module HttpUtils = Http_utils
 module Input = Component.Input
@@ -8,9 +9,9 @@ let tags_path ?suffix () =
   CCOption.map_or ~default (Format.asprintf "%s%s" default) suffix
 ;;
 
-let layout language children =
+let layout ?(id = "") language children =
   div
-    ~a:[ a_class [ "trim"; "safety-margin" ] ]
+    ~a:[ a_id id; a_class [ "trim"; "safety-margin" ] ]
     (h1
        ~a:[ a_class [ "heading-1" ] ]
        [ txt Pool_common.(Utils.nav_link_to_string language I18n.Tags) ]
@@ -49,14 +50,49 @@ module List = struct
   ;;
 end
 
-let index ({ Pool_context.language; _ } as context) tags =
+let index Pool_context.{ language; _ } tags query =
+  let url = Uri.of_string (tags_path ()) in
+  let sort = Component.Sortable_table.{ url; query; language } in
+  let cols =
+    let create_tag : [ | Html_types.flow5 ] elt =
+      Component.Input.link_as_button
+        ~style:`Success
+        ~icon:Component.Icon.Add
+        ~control:(language, Pool_common.Message.(Add (Some Field.Tag)))
+        (tags_path ~suffix:"create" ())
+    in
+    [ `column Tags.column_title
+    ; `column Tags.column_description
+    ; `column Tags.column_model
+    ; `custom create_tag
+    ]
+  in
+  let rows =
+    let open Tags in
+    let buttons tag =
+      tags_path ~suffix:(tag.Tags.id |> Tags.Id.value) ()
+      |> Input.edit_link
+      |> CCList.return
+      |> div ~a:[ a_class [ "flexrow"; "flex-gap"; "justify-end" ] ]
+    in
+    let row (tag : Tags.t) =
+      [ txt (Title.value tag.title)
+      ; txt (CCOption.map_or ~default:"" Tags.Description.value tag.description)
+      ; txt (Model.show tag.model |> String.capitalize_ascii)
+      ; buttons tag
+      ]
+    in
+    CCList.map row tags
+  in
+  let target_id = "tags-table" in
   layout
+    ~id:target_id
     language
     [ p
         [ Pool_common.(Utils.hint_to_string language I18n.TagsIntro)
           |> HttpUtils.add_line_breaks
         ]
-    ; List.create context tags
+    ; Component.Sortable_table.make ~target_id ~cols ~rows sort
     ]
 ;;
 


### PR DESCRIPTION
Hi folks! 👋🏼 Opening this PR to start getting feedback on this.

**Pages**:
- [X] /admin/organisational-unit `Page_admin_organisational_unit`
- [X] /admin/settings/tags `Page_settings_tags`
- [X] /admin/settings/role-permission `Page_settings_rules`
- [X] /admin/settings/smtp `Page_settings_smtp`
- [X] /admin/contacts `Page_admin_contact`
- [X] /admin/experiments `Page_admin_experiments`
- [X] /admin/filter `Page_admin_filter`
- [X] /admin/locations `Page_admin_location`

And currently left these ones aside because the sorting proved harder than expected:
- [ ] ~~/admin/custom-fields/contact `Page_admin_custom_fields`~~ – the whole grouping and resorting there i think could use some cleaning up.

- [ ] ~~/admin/admins `Page_admin_admins`~~

- [ ] ~~/admin/settings/queue `Page_settings_queue`~~

- [ ] ~~/admin/message-template `Page_admin_message_templates`~~ – this page defines a table that is reused in other places (including editing views), so before going through those hoops I wanted to double check if it was worth the time.

And this ones I got built and running but have a hard time testing:
- [X] /admin/settings/schedules `Page_settings_schedule`