### PR TITLE
Bug/externalize

### DIFF
--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -782,7 +782,7 @@ let cell_phone_input ?(required = false) () =
               ([ a_name Pool_common.Message.Field.(show CellPhone)
                ; a_class [ "input" ]
                ; a_input_type `Text
-               ; a_pattern "^[1-9]\d{3,12}"
+               ; a_pattern {|^[1-9]\d{3,12}|}
                ; a_placeholder "791234567"
                ]
                @ attrs)

--- a/pool/web/view/component/sortable_table.ml
+++ b/pool/web/view/component/sortable_table.ml
@@ -66,7 +66,7 @@ let sort_icon sort col =
 ;;
 
 let make_sortable_head id sort col =
-  let url = make_url sort col in
+  let url = make_url sort col |> Sihl.Web.externalize_path in
   span
     ~a:(hx_get ~url ~target:("#" ^ id) @ [ a_class [ "has-icon"; "pointer" ] ])
     (if is_selected sort col

--- a/pool/web/view/page/page_admin_settings_smtp.ml
+++ b/pool/web/view/page/page_admin_settings_smtp.ml
@@ -34,6 +34,7 @@ let index Pool_context.{ language; _ } location smtp_auth_list =
     let open SmtpAuth in
     let action_path =
       Format.asprintf "%s/%s/delete" (base_path location) (auth.id |> Id.value)
+      |> Sihl.Web.externalize_path
     in
     form
       ~a:


### PR DESCRIPTION
While testing the latest changes on our staging environment:

- use a quoted string literal (removes warning about backslash in string)
- externalize sortable table URLs (e.g. needed for /staging path prefix - otherwise, search/sort requests are going to the production URL)


@leostera Sorry, I guess I didn't mention that earlier.