### PR TITLE
Use Lwt.reraise over Lwt.fail

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -9,17 +9,17 @@
 (authors "Department of Economics, University of Zurich")
 
 (source
- (uri git+https://github.com/uzh/z-pool-tool))
+ (uri git+<https://github.com/uzh/z-pool-tool>))
 
 (license GPL-2.0-or-later)
 
-(maintainers "engineering@uzh.econ.ch")
+(maintainers "<engineering@uzh.econ.ch>")
 
-(homepage "https://github.com/uzh/z-pool-tool")
+(homepage "<https://github.com/uzh/z-pool-tool>")
 
-(bug_reports "https://github.com/uzh/z-pool-tool")
+(bug_reports "<https://github.com/uzh/z-pool-tool>")
 
-(documentation "https://uzh.github.io/z-pool-tool-documentation/")
+(documentation "<https://uzh.github.io/z-pool-tool-documentation/>")
 
 (package
  (name pool)
@@ -46,7 +46,7 @@
   (logs
    (>= 0.7.0))
   (lwt
-   (>= 5.6.1))
+   (>= 5.7.0))
   (mariadb
    (and
     (>= 1.2.0)

--- a/pool.opam
+++ b/pool.opam
@@ -25,7 +25,7 @@ depends: [
   "digestif"
   "guardian" {= "0.4.0"}
   "logs" {>= "0.7.0"}
-  "lwt" {>= "5.6.1"}
+  "lwt" {>= "5.7.0"}
   "mariadb" {>= "1.2.0" & < "2.0.0"}
   "ocaml" {>= "4.14.0"}
   "ocaml-lsp-server" {with-dev-setup}

--- a/pool/database/pools.ml
+++ b/pool/database/pools.ml
@@ -316,7 +316,7 @@ module Make (Config : Pools_sig.ConfigSig) = struct
         Logs.debug (fun m -> m "Successfully rolled back transaction"))
       |> Pool.raise_caqti_error label
     in
-    Lwt.fail error
+    Lwt.reraise error
   ;;
 
   let transaction

--- a/pool/web/middleware/middleware_logger.ml
+++ b/pool/web/middleware/middleware_logger.ml
@@ -113,7 +113,7 @@ let logger =
       (fun exn ->
          Logs.err ~src (fun m -> m ~tags "%s" (Exn.to_string exn));
          Logs.err ~src (fun m -> m ~tags "%s" (Printexc.get_backtrace ()));
-         Lwt.fail exn)
+         Lwt.reraise exn)
   in
   Rock.Middleware.create ~name:"Logger" ~filter
 ;;


### PR DESCRIPTION
`Lwt.reraise` preserves backtraces while `Lwt.fail` doesn't.

Available since lwt.5.7.0. We already had that requirement in esy.json but not in `dune-project` / `pool.opam` - `pool.opam.locked` is at a much more recent version.
https://github.com/ocsigen/lwt/blob/4714cea1b73aaccf1ea2ea2a18db565070ca680c/CHANGES#L129